### PR TITLE
fix: accept 0x3e frames, binary req field order, BinaryResponse offset, request_neighbours wire format

### DIFF
--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -776,7 +776,9 @@ impl CommandHandler {
 
     /// Send a binary request to a contact
     ///
-    /// Format: [CMD_SEND_BINARY_REQ=0x32][req_type][pubkey: 32]
+    /// Format: [CMD_SEND_BINARY_REQ=0x32][pubkey: 32][req_type]
+    /// (Firmware and canonical meshcore_py use pubkey-then-type; see
+    /// meshcore_py commands/base.py:244.)
     pub async fn send_binary_req(
         &self,
         dest: impl Into<Destination>,
@@ -788,8 +790,8 @@ impl CommandHandler {
         })?;
 
         let mut data = vec![CMD_SEND_BINARY_REQ];
-        data.push(req_type as u8);
         data.extend_from_slice(&pubkey);
+        data.push(req_type as u8);
 
         let event = self.send(&data, Some(EventType::MsgSent)).await?;
 

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -895,25 +895,36 @@ impl CommandHandler {
         }
     }
 
-    /// Request neighbours from a contact
+    /// Request neighbours from a contact.
+    ///
+    /// Defaults: `order_by = 0`, `pubkey_prefix_length = 4` (matches meshcore_py default).
     pub async fn request_neighbours(
         &self,
         dest: impl Into<Destination>,
-        count: u16,
+        count: u8,
         offset: u16,
     ) -> Result<NeighboursData> {
-        self.request_neighbours_with_timeout(dest, count, offset, self.default_timeout)
+        self.request_neighbours_with_timeout(dest, count, offset, 0, 4, self.default_timeout)
             .await
     }
 
-    /// Request neighbours with custom timeout
+    /// Request neighbours with custom timeout and options.
     ///
-    /// Format: [CMD_SEND_BINARY_REQ=0x32][req_type][pubkey: 32][count: u16][offset: u16]
+    /// Canonical wire format (matches meshcore_py `commands/binary.py::req_neighbours_async`):
+    ///
+    /// `[CMD_SEND_BINARY_REQ=0x32][pubkey: 32][type=NEIGHBOURS=0x02]`
+    /// `[version: u8 = 0][count: u8][offset: u16 LE][order_by: u8][pk_plen: u8][nonce: u32 LE]`
+    ///
+    /// The firmware echoes `pk_plen` in the response's per-entry pubkey width;
+    /// the reader reads that back via the `pubkey_prefix_length` context attribute
+    /// so `parse_neighbours` uses the correct entry stride.
     pub async fn request_neighbours_with_timeout(
         &self,
         dest: impl Into<Destination>,
-        count: u16,
+        count: u8,
         offset: u16,
+        order_by: u8,
+        pubkey_prefix_length: u8,
         timeout: Duration,
     ) -> Result<NeighboursData> {
         let dest: Destination = dest.into();
@@ -921,11 +932,29 @@ impl CommandHandler {
             Error::invalid_param("Neighbours request requires full 32-byte public key")
         })?;
 
+        // Non-zero nonce derived from the system clock; the firmware only needs
+        // uniqueness for request/response correlation, not cryptographic entropy.
+        let nonce = {
+            let n = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(1);
+            if n == 0 {
+                1
+            } else {
+                n
+            }
+        };
+
         let mut data = vec![CMD_SEND_BINARY_REQ];
-        data.push(BinaryReqType::Neighbours as u8);
         data.extend_from_slice(&pubkey);
-        data.extend_from_slice(&count.to_le_bytes());
+        data.push(BinaryReqType::Neighbours as u8);
+        data.push(0u8); // version
+        data.push(count);
         data.extend_from_slice(&offset.to_le_bytes());
+        data.push(order_by);
+        data.push(pubkey_prefix_length);
+        data.extend_from_slice(&nonce.to_le_bytes());
 
         let event = self.send(&data, Some(EventType::MsgSent)).await?;
         let sent = match event.payload {
@@ -933,14 +962,19 @@ impl CommandHandler {
             _ => return Err(Error::protocol("Unexpected response to neighbours request")),
         };
 
-        // Register the request
+        // Pass pk_plen through to the reader so `parse_neighbours` uses the right stride.
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "pubkey_prefix_length".to_string(),
+            pubkey_prefix_length.to_string(),
+        );
         self.reader
             .register_binary_request(
                 &sent.expected_ack,
                 BinaryReqType::Neighbours,
                 pubkey.to_vec(),
                 timeout,
-                HashMap::new(),
+                ctx,
                 false,
             )
             .await;

--- a/src/meshcore/mod.rs
+++ b/src/meshcore/mod.rs
@@ -3,7 +3,7 @@
 use crate::commands::CommandHandler;
 use crate::events::*;
 #[cfg(any(feature = "serial", feature = "tcp"))]
-use crate::packets::FRAME_START;
+use crate::packets::{FRAME_START, FRAME_START_RESP};
 use crate::reader::MessageReader;
 use crate::Result;
 #[cfg(any(feature = "serial", feature = "tcp"))]
@@ -392,7 +392,10 @@ pub async fn read_task<R>(
                 buffer.extend_from_slice(&read_buf[..n]);
 
                 while buffer.len() >= 3 {
-                    if buffer[0] != FRAME_START {
+                    // The MeshCore companion protocol uses 0x3c for
+                    // app → radio frames and 0x3e for radio → app frames.
+                    // Accept either so we can read responses correctly.
+                    if buffer[0] != FRAME_START && buffer[0] != FRAME_START_RESP {
                         use bytes::Buf;
                         buffer.advance(1);
                         continue;

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -187,8 +187,11 @@ impl From<u8> for ControlType {
     }
 }
 
-/// Frame start marker byte
+/// Frame start marker byte (app → radio, commands)
 pub const FRAME_START: u8 = 0x3c;
+
+/// Frame start marker byte (radio → app, responses)
+pub const FRAME_START_RESP: u8 = 0x3e;
 
 /// Default serial baud rate
 pub const DEFAULT_BAUD_RATE: u32 = 115200;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -520,8 +520,15 @@ impl MessageReader {
                                 )
                             }
                             BinaryReqType::Neighbours => {
-                                // Default to 6-byte pubkey prefix
-                                if let Ok(neighbours) = parse_neighbours(&data, 6) {
+                                // Firmware echoes pubkey prefix of the length the client
+                                // requested. `request_neighbours_with_timeout` stashes that
+                                // value in the context; default to 4 to match meshcore_py.
+                                let pk_plen = req
+                                    .context
+                                    .get("pubkey_prefix_length")
+                                    .and_then(|s| s.parse::<usize>().ok())
+                                    .unwrap_or(4);
+                                if let Ok(neighbours) = parse_neighbours(&data, pk_plen) {
                                     MeshCoreEvent::new(
                                         EventType::NeighboursResponse,
                                         EventPayload::Neighbours(neighbours),
@@ -1981,14 +1988,19 @@ mod tests {
         let (reader, dispatcher) = create_reader();
         let mut receiver = dispatcher.receiver();
 
-        // Register a pending Neighbors request
+        // Register a pending Neighbors request. The test data below uses 6-byte
+        // pubkey prefixes, so seed the context accordingly — in production the
+        // request builder sets this to whatever prefix length it negotiated
+        // (default 4 per meshcore_py).
+        let mut ctx = HashMap::new();
+        ctx.insert("pubkey_prefix_length".to_string(), "6".to_string());
         reader
             .register_binary_request(
                 &[0x01, 0x02, 0x03, 0x04],
                 BinaryReqType::Neighbours,
                 vec![],
                 Duration::from_secs(30),
-                HashMap::new(),
+                ctx,
                 false,
             )
             .await;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -473,9 +473,13 @@ impl MessageReader {
             }
 
             PacketType::BinaryResponse => {
-                if payload.len() >= 4 {
-                    let tag: [u8; 4] = read_bytes(payload, 0).unwrap_or([0; 4]);
-                    let data = payload[4..].to_vec();
+                // Firmware layout: [subtype: 1][tag: 4][data...]
+                // Skip the subtype byte; tag lives at offset 1, data from offset 5.
+                // See meshcore_py reader.py:727:
+                //   dbuf.read(1); tag = dbuf.read(4).hex(); response_data = dbuf.read()
+                if payload.len() >= 5 {
+                    let tag: [u8; 4] = read_bytes(payload, 1).unwrap_or([0; 4]);
+                    let data = payload[5..].to_vec();
 
                     // Check if we have a pending request for this tag
                     let tag_hex = hex_encode(&tag);
@@ -1458,6 +1462,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // telemetry data
 
@@ -1478,6 +1483,7 @@ mod tests {
         let mut receiver = dispatcher.receiver();
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // tag
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // data
 
@@ -1911,6 +1917,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // ACL entry data (7 bytes per entry)
         data.extend_from_slice(&[0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x01]);
@@ -1950,6 +1957,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // MMA entry (14 bytes)
         data.push(1); // channel
@@ -1986,6 +1994,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // Neighbours data
         data.extend_from_slice(&1u16.to_le_bytes()); // total
@@ -2023,6 +2032,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // Status data (52 bytes)
         let mut status_data = vec![0u8; 52];
@@ -2057,6 +2067,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte (firmware layout: [subtype][tag:4][data…])
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
         data.extend_from_slice(&[0xAA, 0xBB]);
 


### PR DESCRIPTION
## Summary

Four interrelated fixes found while building a Rust/Tauri desktop client against a LilyGO T-Echo running MeshCore Companion USB v1.14.1 and a v1.12.0 repeater:

1. **`packets.rs`**: add `FRAME_START_RESP = 0x3e` for the radio→app direction
2. **`meshcore/mod.rs`** (`read_task`): accept `0x3e` alongside `0x3c` — without this, every response from the companion is silently discarded
3. **`commands/base.rs`** (`send_binary_req`): fix field order to `[CMD][pubkey: 32][req_type]` (was `[CMD][req_type][pubkey]`), matching firmware and `meshcore_py`
4. **`reader.rs`** (`BinaryResponse`): firmware layout is `[subtype: 1][tag: 4][data…]`; skip the subtype byte when reading tag/data
5. **`commands/base.rs` + `reader.rs`** (`request_neighbours`): complete rewrite of the wire format. Previous implementation sent a malformed body and hardcoded 6-byte response prefixes. Canonical format is now:
   - Request: `[CMD][pubkey:32][type=NEIGHBOURS][version:u8=0][count:u8][offset:u16 LE][order_by:u8][pk_plen:u8][nonce:u32 LE]`
   - Response: per-entry pubkey width matches the client-requested `pk_plen`, threaded through via the binary-request context map (mirrors `meshcore_py`'s context mechanism)
   - **API change** (the previous function was unusable): `count: u16` → `count: u8`, and `request_neighbours_with_timeout` gains `order_by: u8` and `pubkey_prefix_length: u8` parameters

## Test plan

- [x] `request_telemetry` round-trip against KD6O rooftop repeater (v1.12.0) via T-Echo companion — returns valid LPP payload with voltage and temperature (fixes 1–4)
- [x] `request_neighbours` against the same repeater — zero before this PR, 3 neighbors matching `meshcore_cli req_neighbours` output after (fix 5)
- [x] All files compile cleanly with `cargo check`
- [x] Cross-checked every field order and offset against `meshcore_py`'s `commands/binary.py` and `reader.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)