### PR TITLE
fix: BinaryResponse tag offset — skip subtype byte

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -473,9 +473,13 @@ impl MessageReader {
             }
 
             PacketType::BinaryResponse => {
-                if payload.len() >= 4 {
-                    let tag: [u8; 4] = read_bytes(payload, 0).unwrap_or([0; 4]);
-                    let data = payload[4..].to_vec();
+                // Firmware layout: [subtype: 1][tag: 4][data...]
+                // Skip the subtype byte; tag lives at offset 1, data from offset 5.
+                // See meshcore_py reader.py:727:
+                //   dbuf.read(1); tag = dbuf.read(4).hex(); response_data = dbuf.read()
+                if payload.len() >= 5 {
+                    let tag: [u8; 4] = read_bytes(payload, 1).unwrap_or([0; 4]);
+                    let data = payload[5..].to_vec();
 
                     // Check if we have a pending request for this tag
                     let tag_hex = hex_encode(&tag);
@@ -1458,6 +1462,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // telemetry data
 
@@ -1478,6 +1483,7 @@ mod tests {
         let mut receiver = dispatcher.receiver();
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // tag
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC]); // data
 
@@ -1911,6 +1917,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // ACL entry data (7 bytes per entry)
         data.extend_from_slice(&[0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x01]);
@@ -1950,6 +1957,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // MMA entry (14 bytes)
         data.push(1); // channel
@@ -1986,6 +1994,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // Neighbours data
         data.extend_from_slice(&1u16.to_le_bytes()); // total
@@ -2023,6 +2032,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
                                                            // Status data (52 bytes)
         let mut status_data = vec![0u8; 52];
@@ -2057,6 +2067,7 @@ mod tests {
             .await;
 
         let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
         data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
         data.extend_from_slice(&[0xAA, 0xBB]);
 
@@ -2068,6 +2079,58 @@ mod tests {
             .unwrap();
 
         assert_eq!(event.event_type, EventType::BinaryResponse);
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_binary_response_subtype_byte_skipped() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        reader
+            .register_binary_request(
+                &[0x01, 0x02, 0x03, 0x04],
+                BinaryReqType::Telemetry,
+                vec![],
+                Duration::from_secs(30),
+                HashMap::new(),
+                false,
+            )
+            .await;
+
+        // Verify that different subtype values don't affect tag correlation
+        let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0xFF); // non-zero subtype byte — should be ignored
+        data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
+        data.extend_from_slice(&[0xDE, 0xAD]); // telemetry data
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::TelemetryResponse);
+        match event.payload {
+            EventPayload::Telemetry(d) => assert_eq!(d, vec![0xDE, 0xAD]),
+            _ => panic!("Expected Telemetry payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_binary_response_too_short() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // Payload with only 4 bytes (less than the 5-byte minimum for subtype+tag)
+        let mut data = vec![PacketType::BinaryResponse as u8];
+        data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]);
+
+        reader.handle_rx(data).await.unwrap();
+
+        // Should not emit any event since payload < 5 bytes
+        let result = tokio::time::timeout(Duration::from_millis(50), receiver.recv()).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Extracted from PR #28 (fix 3). Depends on PR #29.

Firmware sends BinaryResponse packets as `[subtype: 1][tag: 4][data...]`, but meshcore-rs was reading the tag at offset 0 — corrupting tag correlation. This fix skips the subtype byte, reading the tag from offset 1 and data from offset 5.

### Correctness verification vs meshcore_py

meshcore_py at `reader.py:727`:
```python
elif packet_type_value == PacketType.BINARY_RESPONSE.value:
    dbuf.read(1)              # skip subtype byte
    tag = dbuf.read(4).hex()  # tag is 4 bytes at offset 1
    response_data = dbuf.read()
```

Wire layout is `[subtype: 1][tag: 4][data…]` — this PR matches that exactly.

### Impact

Without this fix, the pending-request dispatcher never matched binary responses to their callers. All binary responses were emitted as generic `BinaryResponse` events instead of typed events (`TelemetryResponse`, `StatusResponse`, `NeighboursResponse`, etc.). This broke `request_telemetry`, `request_status`, `request_neighbours`, `request_acl`, and `request_mma`.

## Test plan

- [x] All 244 tests pass (2 new tests added)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] Updated all 7 BinaryResponse test payloads to include subtype byte
- [x] New test verifies non-zero subtype values are correctly skipped
- [x] New test verifies payloads shorter than 5 bytes are silently ignored

Credit: Original fix by @artbotterell in #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)