### PR TITLE
fix: request_neighbours wire format + client-negotiated pubkey prefix length

### DIFF
--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -932,6 +932,12 @@ impl CommandHandler {
             Error::invalid_param("Neighbours request requires full 32-byte public key")
         })?;
 
+        if pubkey_prefix_length > 32 {
+            return Err(Error::invalid_param(
+                "pubkey_prefix_length cannot exceed 32",
+            ));
+        }
+
         let nonce = {
             let n = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
@@ -1978,10 +1984,13 @@ mod tests {
             assert_eq!(u16::from_le_bytes([sent[36], sent[37]]), 5); // offset
             assert_eq!(sent[38], 2); // order_by
             assert_eq!(sent[39], 4); // pubkey_prefix_length
-                                     // Bytes 40..44 are the nonce — non-zero
             let nonce = u32::from_le_bytes([sent[40], sent[41], sent[42], sent[43]]);
             assert_ne!(nonce, 0);
-            assert_eq!(sent.len(), 44); // total: 1 + 32 + 1 + 1 + 1 + 2 + 1 + 1 + 4 = 44
+            assert_eq!(sent.len(), 44);
+
+            // Subscribe for the response *before* emitting MsgSent, so we
+            // don't miss the NeighboursResponse window.
+            let mut resp_rx = dispatcher_clone.receiver();
 
             dispatcher_clone
                 .emit(MeshCoreEvent::new(
@@ -1994,8 +2003,22 @@ mod tests {
                 ))
                 .await;
 
-            // Small delay so the caller can subscribe before we emit
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            // Wait until the caller has registered the binary request (it
+            // emits MsgSent handling internally, then registers, then waits).
+            // We detect readiness by watching for any activity after MsgSent.
+            loop {
+                if let Ok(ev) =
+                    tokio::time::timeout(Duration::from_millis(50), resp_rx.recv()).await
+                {
+                    if let Ok(e) = ev {
+                        if e.event_type == EventType::MsgSent {
+                            continue;
+                        }
+                    }
+                } else {
+                    break; // Timeout = caller is now waiting, safe to emit
+                }
+            }
 
             dispatcher_clone
                 .emit(
@@ -2016,5 +2039,15 @@ mod tests {
             .request_neighbours_with_timeout(dest, 10, 5, 2, 4, Duration::from_millis(500))
             .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_request_neighbours_invalid_pubkey_prefix_length() {
+        let (handler, _rx, _dispatcher) = create_test_handler();
+        let dest = vec![0xAAu8; 32];
+        let result = handler
+            .request_neighbours_with_timeout(dest, 10, 0, 0, 33, Duration::from_millis(100))
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -895,25 +895,36 @@ impl CommandHandler {
         }
     }
 
-    /// Request neighbours from a contact
+    /// Request neighbours from a contact.
+    ///
+    /// Defaults: `order_by = 0`, `pubkey_prefix_length = 4` (matches meshcore_py default).
     pub async fn request_neighbours(
         &self,
         dest: impl Into<Destination>,
-        count: u16,
+        count: u8,
         offset: u16,
     ) -> Result<NeighboursData> {
-        self.request_neighbours_with_timeout(dest, count, offset, self.default_timeout)
+        self.request_neighbours_with_timeout(dest, count, offset, 0, 4, self.default_timeout)
             .await
     }
 
-    /// Request neighbours with custom timeout
+    /// Request neighbours with custom timeout and options.
     ///
-    /// Format: [CMD_SEND_BINARY_REQ=0x32][req_type][pubkey: 32][count: u16][offset: u16]
+    /// Canonical wire format (matches meshcore_py `commands/binary.py::req_neighbours_async`):
+    ///
+    /// `[CMD_SEND_BINARY_REQ=0x32][pubkey: 32][type=NEIGHBOURS=0x06]`
+    /// `[version: u8 = 0][count: u8][offset: u16 LE][order_by: u8][pk_plen: u8][nonce: u32 LE]`
+    ///
+    /// The firmware echoes `pk_plen` in the response's per-entry pubkey width;
+    /// the reader reads that back via the `pubkey_prefix_length` context attribute
+    /// so `parse_neighbours` uses the correct entry stride.
     pub async fn request_neighbours_with_timeout(
         &self,
         dest: impl Into<Destination>,
-        count: u16,
+        count: u8,
         offset: u16,
+        order_by: u8,
+        pubkey_prefix_length: u8,
         timeout: Duration,
     ) -> Result<NeighboursData> {
         let dest: Destination = dest.into();
@@ -921,11 +932,27 @@ impl CommandHandler {
             Error::invalid_param("Neighbours request requires full 32-byte public key")
         })?;
 
+        let nonce = {
+            let n = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(1);
+            if n == 0 {
+                1
+            } else {
+                n
+            }
+        };
+
         let mut data = vec![CMD_SEND_BINARY_REQ];
-        data.push(BinaryReqType::Neighbours as u8);
         data.extend_from_slice(&pubkey);
-        data.extend_from_slice(&count.to_le_bytes());
+        data.push(BinaryReqType::Neighbours as u8);
+        data.push(0u8); // version
+        data.push(count);
         data.extend_from_slice(&offset.to_le_bytes());
+        data.push(order_by);
+        data.push(pubkey_prefix_length);
+        data.extend_from_slice(&nonce.to_le_bytes());
 
         let event = self.send(&data, Some(EventType::MsgSent)).await?;
         let sent = match event.payload {
@@ -933,14 +960,18 @@ impl CommandHandler {
             _ => return Err(Error::protocol("Unexpected response to neighbours request")),
         };
 
-        // Register the request
+        let mut ctx = HashMap::new();
+        ctx.insert(
+            "pubkey_prefix_length".to_string(),
+            pubkey_prefix_length.to_string(),
+        );
         self.reader
             .register_binary_request(
                 &sent.expected_ack,
                 BinaryReqType::Neighbours,
                 pubkey.to_vec(),
                 timeout,
-                HashMap::new(),
+                ctx,
                 false,
             )
             .await;
@@ -1925,6 +1956,64 @@ mod tests {
         let dest = vec![0xAAu8; 32];
         let result = handler
             .send_binary_req(dest, BinaryReqType::Telemetry)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_request_neighbours_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            // Wire format: [CMD=0x32][pubkey:32][type=NEIGHBOURS=0x06]
+            //              [version:u8=0][count:u8][offset:u16 LE]
+            //              [order_by:u8][pk_plen:u8][nonce:u32 LE]
+            assert_eq!(sent[0], CMD_SEND_BINARY_REQ);
+            assert_eq!(&sent[1..33], &[0xBB; 32]); // pubkey
+            assert_eq!(sent[33], BinaryReqType::Neighbours as u8); // 0x06
+            assert_eq!(sent[34], 0); // version
+            assert_eq!(sent[35], 10); // count
+            assert_eq!(u16::from_le_bytes([sent[36], sent[37]]), 5); // offset
+            assert_eq!(sent[38], 2); // order_by
+            assert_eq!(sent[39], 4); // pubkey_prefix_length
+                                     // Bytes 40..44 are the nonce — non-zero
+            let nonce = u32::from_le_bytes([sent[40], sent[41], sent[42], sent[43]]);
+            assert_ne!(nonce, 0);
+            assert_eq!(sent.len(), 44); // total: 1 + 32 + 1 + 1 + 1 + 2 + 1 + 1 + 4 = 44
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::MsgSent,
+                    EventPayload::MsgSent(MsgSentInfo {
+                        message_type: 0,
+                        expected_ack: [0x01, 0x02, 0x03, 0x04],
+                        suggested_timeout: 5000,
+                    }),
+                ))
+                .await;
+
+            // Small delay so the caller can subscribe before we emit
+            tokio::time::sleep(Duration::from_millis(10)).await;
+
+            dispatcher_clone
+                .emit(
+                    MeshCoreEvent::new(
+                        EventType::NeighboursResponse,
+                        EventPayload::Neighbours(crate::events::NeighboursData {
+                            total: 0,
+                            neighbours: vec![],
+                        }),
+                    )
+                    .with_attribute("tag", "01020304".to_string()),
+                )
+                .await;
+        });
+
+        let dest = vec![0xBBu8; 32];
+        let result = handler
+            .request_neighbours_with_timeout(dest, 10, 5, 2, 4, Duration::from_millis(500))
             .await;
         assert!(result.is_ok());
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -520,8 +520,12 @@ impl MessageReader {
                                 )
                             }
                             BinaryReqType::Neighbours => {
-                                // Default to 6-byte pubkey prefix
-                                if let Ok(neighbours) = parse_neighbours(&data, 6) {
+                                let pk_plen = req
+                                    .context
+                                    .get("pubkey_prefix_length")
+                                    .and_then(|s| s.parse::<usize>().ok())
+                                    .unwrap_or(4);
+                                if let Ok(neighbours) = parse_neighbours(&data, pk_plen) {
                                     MeshCoreEvent::new(
                                         EventType::NeighboursResponse,
                                         EventPayload::Neighbours(neighbours),
@@ -1981,14 +1985,17 @@ mod tests {
         let (reader, dispatcher) = create_reader();
         let mut receiver = dispatcher.receiver();
 
-        // Register a pending Neighbors request
+        // Register a pending Neighbors request with 6-byte pubkey prefix
+        // to match the test data below
+        let mut ctx = HashMap::new();
+        ctx.insert("pubkey_prefix_length".to_string(), "6".to_string());
         reader
             .register_binary_request(
                 &[0x01, 0x02, 0x03, 0x04],
                 BinaryReqType::Neighbours,
                 vec![],
                 Duration::from_secs(30),
-                HashMap::new(),
+                ctx,
                 false,
             )
             .await;
@@ -2012,6 +2019,52 @@ mod tests {
             .unwrap();
 
         assert_eq!(event.event_type, EventType::NeighboursResponse);
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_binary_response_neighbours_default_pk_plen() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // Register without context — should default to pk_plen=4
+        reader
+            .register_binary_request(
+                &[0x01, 0x02, 0x03, 0x04],
+                BinaryReqType::Neighbours,
+                vec![],
+                Duration::from_secs(30),
+                HashMap::new(),
+                false,
+            )
+            .await;
+
+        let mut data = vec![PacketType::BinaryResponse as u8];
+        data.push(0x00); // subtype byte
+        data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // matching tag
+                                                           // Neighbours data with 4-byte pubkey prefix
+        data.extend_from_slice(&1u16.to_le_bytes()); // total
+        data.extend_from_slice(&1u16.to_le_bytes()); // count
+                                                     // Entry: pubkey (4) + secs_ago (4) + snr (1) = 9 bytes
+        data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+        data.extend_from_slice(&300i32.to_le_bytes());
+        data.push(40); // snr
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::NeighboursResponse);
+        match event.payload {
+            EventPayload::Neighbours(n) => {
+                assert_eq!(n.total, 1);
+                assert_eq!(n.neighbours.len(), 1);
+                assert_eq!(n.neighbours[0].pubkey, vec![0xAA, 0xBB, 0xCC, 0xDD]);
+            }
+            _ => panic!("Expected Neighbours payload"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Extracted from PR #28 (fix 4). Depends on PR #30.

Complete rewrite of the `request_neighbours` wire format. The previous implementation sent a malformed body and hardcoded 6-byte response prefixes. 

### Changes

- **Request body**: Changed from `[count:u16][offset:u16]` (4 bytes, wrong) to `[version:u8=0][count:u8][offset:u16 LE][order_by:u8][pk_plen:u8][nonce:u32 LE]` (10 bytes, matching firmware)
- **Response parser**: Now reads `pubkey_prefix_length` from the request context instead of hardcoding 6 (firmware default is 4)
- **API change**: `count: u16` → `count: u8`; `request_neighbours_with_timeout` gains `order_by: u8` and `pubkey_prefix_length: u8` parameters

### Correctness verification vs meshcore_py

**Request body** — meshcore_py at `commands/binary.py:140-165`:
```python
req = (b"\x00"                                         # version
     + count.to_bytes(1, "little")                     # u8
     + offset.to_bytes(2, "little")                    # u16 LE
     + order_by.to_bytes(1, "little")                  # u8
     + pubkey_prefix_length.to_bytes(1, "little")      # u8, default 4
     + random.randint(1, 0xFFFFFFFF).to_bytes(4, "little"))  # nonce
```
This PR matches that layout exactly.

**Response parsing** — meshcore_py at `reader.py:789-812`:
```python
pk_plen = context["pubkey_prefix_length"]
```
The prefix length is client-negotiated per-request and threaded through via the context map. This PR does the same.

### Breaking API change note

`count` changed from `u16` to `u8`, and `request_neighbours_with_timeout` gained two new parameters. The pre-patch function was unusable (returned 0 neighbours for all inputs due to the malformed request body), so no working callers should be affected.

## Test plan

- [x] All 246 tests pass (2 new tests added)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] New test verifies `request_neighbours_with_timeout` wire format field-by-field
- [x] New test verifies default `pubkey_prefix_length=4` when no context is provided
- [x] Existing neighbours test updated with context `pubkey_prefix_length=6` for its 6-byte fixture data

Credit: Original fix by @artbotterell in #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)