### PR TITLE
Pin lcov to stable v2.4 to fix macOS CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
         if: runner.os != 'Windows'
         uses: hrishikesh-kadam/setup-lcov@v1
         with:
-          ref: HEAD
+          ref: v2.4
 
       - name: Install dependencies - Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- Pin lcov from unstable `HEAD` to stable `v2.4` in the CI workflow
- The HEAD build now requires `sphinx-build` which isn't on the macOS runner, causing `Setup LCOV` to fail with `sphinx-build: command not found`
- Fixes https://github.com/andrewdavidmackenzie/meshcore-rs/actions/runs/26720047086/job/78745357353

## Test plan
- [ ] CI passes on all matrix targets (ubuntu, macOS, windows, ARM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)