### PR TITLE
Bump codecov-action from v5 to v7

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: UploadCoverage
         if: runner.os != 'Windows'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- Bumps `codecov/codecov-action` from v5 to v7 to fix GPG signature verification failure
- Codecov migrated their Keybase account from `codecovsecurity` to `codecovsecops`, breaking v5/v6
- [v7.0.0](https://github.com/codecov/codecov-action/releases/tag/v7.0.0) released 2026-06-07 with the fix

## Test plan
- [ ] CI passes with codecov upload succeeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)