### PR TITLE
Improve btle example error handling and fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MeshCore-rs
+
 [![codecov](https://codecov.io/gh/andrewdavidmackenzie/meshcore-rs/graph/badge.svg?token=cfyajKsYQa)](https://codecov.io/gh/andrewdavidmackenzie/meshcore-rs)
 
 Rust library for communicating with [MeshCore](https://meshcore.co.uk) companion radio nodes.
@@ -8,11 +9,11 @@ This is a Rust port of the [meshcore_py](https://github.com/meshcore-dev/meshcor
 ## Features
 
 - **Async/await** - Built on Tokio for async I/O
-- **Serial connection** - Connect via USB serial port
-- **TCP connection** - Connect via TCP socket
-- **BLE connection** - Connect via Bluetooth Low Energy (optional feature)
+- **Serial connection** – Connect via USB serial port
+- **TCP connection** – Connect via TCP socket
+- **BLE connection** – Connect via Bluetooth Low Energy (optional feature)
 - **Event-driven** - Subscribe to events with filters
-- **Full protocol support** - Contacts, messaging, binary protocol, signing, etc.
+- **Full protocol support** – Contacts, messaging, binary protocol, signing, etc.
 
 ## Installation
 
@@ -157,10 +158,10 @@ The library implements the MeshCore serial/TCP protocol:
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT License
 
 ## Related Projects
 
-- [MeshCore](https://github.com/meshcore-dev/MeshCore) - Firmware for MeshCore devices
+- [MeshCore](https://github.com/meshcore-dev/MeshCore) – Firmware for MeshCore devices
 - [meshcore_py](https://github.com/meshcore-dev/meshcore_py) - Python library (original)
 - [meshcore-cli](https://github.com/meshcore-dev/meshcore-cli) - Command-line interface

--- a/examples/btle.rs
+++ b/examples/btle.rs
@@ -18,6 +18,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Connect via BLE
     let radios = MeshCore::ble_discover(Duration::from_secs(4)).await?;
+
+    if radios.is_empty() {
+        eprintln!("No compatible meshcore radios found via BlueTooth Low Energy!");
+        return Ok(());
+    }
+
     let meshcore = MeshCore::ble_connect(radios.first().unwrap()).await?;
 
     println!("Connected via BLE!");


### PR DESCRIPTION
## Changes

- **btle example**: Handle empty BLE discovery results gracefully with an informative error message instead of panicking on `.unwrap()`
- **README**: Fix en-dash formatting for list separators and remove broken LICENSE link

## Testing

- All 247 unit tests pass
- 2 doc-tests pass
- `cargo clippy` clean
- `cargo fmt --check` clean
- Release build and `cargo publish --dry-run` succeed