### PR TITLE
fix: make tokio-serial optional so the `serial` feature can be turned off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
 tokio = { version = "1", features = ["full", "sync", "time", "io-util"] }
-tokio-serial = "5"
+tokio-serial = { version = "5", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 thiserror = "2"
 bytes = "1"
@@ -23,9 +23,16 @@ uuid = { version = "1" }
 
 [features]
 default = ["serial", "tcp", "ble"]
-serial = []
+serial = ["dep:tokio-serial"]
 tcp = []
 ble = ["btleplug"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Declared explicitly so `required-features` can be set; without it Cargo
+# auto-discovers this example and tries to build it even when `serial` is off,
+# where `MeshCore::serial` does not exist.
+[[example]]
+name = "serial_usb"
+required-features = ["serial"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum Error {
     Connection(String),
 
     /// Serial port errors
+    #[cfg(feature = "serial")]
     #[error("Serial error: {0}")]
     Serial(#[from] tokio_serial::Error),
 


### PR DESCRIPTION
### Problem

`serial` is declared as a feature, but `tokio-serial` is an unconditional dependency:

```toml
[dependencies]
tokio-serial = "5"

[features]
serial = []
```

So `default-features = false, features = ["tcp", "ble"]` still compiles `tokio-serial` and the native `serialport`/`mio-serial` stack underneath it. The feature toggles the code (`src/meshcore/serial.rs` is already `#[cfg(feature = "serial")]`-gated) but nothing at the dependency level, so a consumer who does not want serial cannot actually avoid building it.

That matters for mobile and cross-compiled targets. On Android the native serial backend is dead weight; on iOS there is no filesystem-level serial device model for it to talk to at all, and `serialport`'s iOS backend references IOKit symbols that iOS's IOKit does not export — so it is not merely unused, it can fail to link.

### Change

```toml
tokio-serial = { version = "5", optional = true }
serial = ["dep:tokio-serial"]
```

Two consequences that had to come with it:

- **`Error::Serial` is cfg-gated.** It is `Serial(#[from] tokio_serial::Error)`, so the enum cannot resolve once the dependency is gone. Worth calling out as a **visible API change when `serial` is disabled**: `Error::Serial` and its `From<tokio_serial::Error>` impl are absent, so an explicit `Error::Serial(_)` match arm would not compile in that configuration. Nothing changes for a default build, and `src/error.rs` was the only place outside the already-gated `serial.rs` that referenced `tokio_serial`.
- **`serial_usb` is declared explicitly with `required-features = ["serial"]`.** Without that, Cargo auto-discovers the example and tries to build it with the feature off, where `MeshCore::serial` does not exist — so `cargo build --examples --no-default-features --features ble,tcp` fails.

### Verification

```
$ cargo tree --no-default-features --features ble,tcp | grep -c tokio-serial
0
$ cargo tree --features serial | grep -c tokio-serial
1
$ cargo build --examples --no-default-features --features ble,tcp
    Finished `dev` profile
$ cargo test --all-features
    249 passed; 0 failed
```

`cargo fmt --all -- --check`, `cargo clippy --tests --no-deps --all-features --all-targets` and `cargo publish --dry-run --allow-dirty --no-verify` are all clean.

(A note on `make checks`: its `publish` target runs a real `cargo publish`, not a dry run, so I ran the sub-targets individually and used the CI workflow's `--dry-run` form instead. `udeps` needs a nightly toolchain I do not have set up locally; CI does not run it either.)
