### PR TITLE
Add the MIT LICENSE file Cargo.toml already declares

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 meshcore-rs authors and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### Problem

`Cargo.toml` declares `license = "MIT"`, and that is published with the crate to crates.io — so the grant itself is clear, and that is what consumers rely on. But the repository has never contained a `LICENSE` file.

The README used to link to one (`MIT License - see [LICENSE](LICENSE) for details`), which 404'd; #54 removed the link rather than adding the file. Entirely reasonable as a quick fix, but it leaves the gap.

### Why it is worth closing

- MIT asks that "the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software". With no terms text in the repository there is nothing concrete for a redistributor to carry — awkward for anyone shipping a binary who maintains a third-party notices file.
- Licence scanners tend to flag `license` metadata with no corresponding file.
- GitHub cannot detect the licence without it: `GET /repos/andrewdavidmackenzie/meshcore-rs/license` currently 404s and the repo's `license` field is `null`, so the sidebar shows nothing.

### The copyright line is deliberately generic

I have written `Copyright (c) 2026 meshcore-rs authors and contributors` rather than naming anyone. **Please change it before merging** — naming who holds copyright is the project's call, not a contributor's, and `git log` shows several people besides yourself. If you would rather take only the terms text and write your own line, or generate the file through GitHub's *Add file → Create new file → LICENSE → Choose a license template* flow instead, that is a better outcome than merging this as-is and I will close it happily.

Raised as a PR rather than an issue only because the file is trivial and it seemed more useful to hand you something to edit than a request to action.
