### PR TITLE
Decode RAW_DATA and LOG_DATA push notifications into structured events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -543,6 +543,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +829,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -543,16 +543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +819,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["meshcore", "lora", "mesh", "radio"]
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
-tokio = { version = "1", default-features = false, features = ["sync", "time", "macros", "rt"] }
+tokio = { version = "1", features = ["full", "sync", "time", "io-util"] }
 tokio-serial = { version = "5", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 thiserror = "2"
@@ -23,13 +23,12 @@ uuid = { version = "1" }
 
 [features]
 default = ["serial", "tcp", "ble"]
-serial = ["dep:tokio-serial", "tokio/io-util"]
-tcp = ["tokio/net", "tokio/io-util"]
+serial = ["dep:tokio-serial"]
+tcp = []
 ble = ["btleplug"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 
 # Declared explicitly so `required-features` can be set; without it Cargo
 # auto-discovers this example and tries to build it even when `serial` is off,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,3 @@ required-features = ["serial"]
 
 [[example]]
 name = "rf_packet_monitor"
-required-features = ["serial"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [[example]]
 name = "serial_usb"
 required-features = ["serial"]
+
+[[example]]
+name = "rf_packet_monitor"
+required-features = ["serial"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,13 @@ keywords = ["meshcore", "lora", "mesh", "radio"]
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
-tokio = { version = "1", features = ["full", "sync", "time", "io-util"] }
+# Baseline needed unconditionally by the core reader/dispatcher/command
+# handler: sync primitives (broadcast/mpsc/Mutex/RwLock), timeouts
+# (tokio::time + the `select!` macro in wait_for_event/wait_for_any_event),
+# and `rt` for the JoinHandle type + tokio::spawn used to drive transports.
+# `io-util` (AsyncRead/Write helpers) and `net` (TcpStream) are only pulled
+# in by the transports that actually need them, see [features] below.
+tokio = { version = "1", default-features = false, features = ["sync", "time", "macros", "rt"] }
 tokio-serial = { version = "5", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 thiserror = "2"
@@ -23,12 +29,18 @@ uuid = { version = "1" }
 
 [features]
 default = ["serial", "tcp", "ble"]
-serial = ["dep:tokio-serial"]
-tcp = []
+serial = ["dep:tokio-serial", "tokio/io-util"]
+tcp = ["tokio/net", "tokio/io-util"]
 ble = ["btleplug"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Examples and doctests use `#[tokio::main]`/`#[tokio::test]` and
+# `tokio::signal::ctrl_c()`; the crate's own baseline `rt` feature only
+# unlocks the current-thread runtime, so building/running them needs
+# `rt-multi-thread` and `signal` on top. This does not affect downstream
+# consumers: dev-dependency features never propagate to them.
+tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 
 # Declared explicitly so `required-features` can be set; without it Cargo
 # auto-discovers this example and tries to build it even when `serial` is off,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,6 @@ keywords = ["meshcore", "lora", "mesh", "radio"]
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
-# Baseline needed unconditionally by the core reader/dispatcher/command
-# handler: sync primitives (broadcast/mpsc/Mutex/RwLock), timeouts
-# (tokio::time + the `select!` macro in wait_for_event/wait_for_any_event),
-# and `rt` for the JoinHandle type + tokio::spawn used to drive transports.
-# `io-util` (AsyncRead/Write helpers) and `net` (TcpStream) are only pulled
-# in by the transports that actually need them, see [features] below.
 tokio = { version = "1", default-features = false, features = ["sync", "time", "macros", "rt"] }
 tokio-serial = { version = "5", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
@@ -35,11 +29,6 @@ ble = ["btleplug"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# Examples and doctests use `#[tokio::main]`/`#[tokio::test]` and
-# `tokio::signal::ctrl_c()`; the crate's own baseline `rt` feature only
-# unlocks the current-thread runtime, so building/running them needs
-# `rt-multi-thread` and `signal` on top. This does not affect downstream
-# consumers: dev-dependency features never propagate to them.
 tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 
 # Declared explicitly so `required-features` can be set; without it Cargo

--- a/README.md
+++ b/README.md
@@ -107,6 +107,51 @@ async fn main() -> Result<(), meshcore_rs::Error> {
 }
 ```
 
+## RF Packet Monitoring
+
+The node pushes a `LogData` event automatically for **every** packet its
+radio receives, whether or not it was addressed to it — no configuration
+required. This is useful for building network visibility tools (coverage
+maps, traffic analysis, etc). The payload carries the signal quality, the
+decoded mesh packet header (route type, payload type, hop path) and, for
+advertisement packets, the advertiser's identity:
+
+```rust
+use meshcore_rs::{MeshCore, EventType};
+use meshcore_rs::events::EventPayload;
+use std::collections::HashMap;
+
+#[tokio::main]
+async fn main() -> Result<(), meshcore_rs::Error> {
+    let meshcore = MeshCore::serial("/dev/ttyUSB0", 115200).await?;
+    meshcore.commands().lock().await.send_appstart().await?;
+
+    let _sub = meshcore.subscribe(
+        EventType::LogData,
+        HashMap::new(),
+        |event| {
+            if let EventPayload::LogData(log) = event.payload {
+                println!("SNR {:.1} dB, RSSI {} dBm", log.snr, log.rssi);
+                if let Some(header) = log.header {
+                    println!("{:?} / {:?}, {} hop(s)", header.route_type, header.payload_type, header.path_len);
+                }
+            }
+        }
+    ).await;
+
+    tokio::signal::ctrl_c().await?;
+    meshcore.disconnect().await?;
+    Ok(())
+}
+```
+
+See `examples/rf_packet_monitor.rs` for a complete, runnable version.
+
+Note: `EventType::RawData` is a different, much narrower event — it only
+fires for directly-routed, not-yet-seen `RAW_CUSTOM` payloads sent by
+another application via the companion `SEND_RAW_DATA` command. Regular mesh
+traffic never triggers it; use `LogData` for general monitoring as above.
+
 ## API Overview
 
 ### Device Commands

--- a/README.md
+++ b/README.md
@@ -145,7 +145,15 @@ async fn main() -> Result<(), meshcore_rs::Error> {
 }
 ```
 
-See `examples/rf_packet_monitor.rs` for a complete, runnable version.
+See `examples/rf_packet_monitor.rs` for a complete, runnable version:
+
+```sh
+cargo run --example rf_packet_monitor --features serial -- --serial /dev/ttyUSB0
+cargo run --example rf_packet_monitor --features ble -- --ble MeshCore-XXXX
+cargo run --example rf_packet_monitor --features tcp -- --tcp 192.168.1.50:5000
+```
+
+Exactly one of `--serial`, `--tcp` or `--ble` is required.
 
 Note: `EventType::RawData` is a different, much narrower event — it only
 fires for directly-routed, not-yet-seen `RAW_CUSTOM` payloads sent by

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ async fn main() -> Result<(), meshcore_rs::Error> {
 The node pushes a `LogData` event automatically for **every** packet its
 radio receives, whether or not it was addressed to it — no configuration
 required. This is useful for building network visibility tools (coverage
-maps, traffic analysis, etc). The payload carries the signal quality, the
+maps, traffic analysis, etc.). The payload carries the signal quality, the
 decoded mesh packet header (route type, payload type, hop path) and, for
 advertisement packets, the advertiser's identity:
 

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,183 @@
+//! Shared helper for examples: pick a MeshCore connection (serial, TCP or
+//! BLE) from the command line.
+
+use meshcore_rs::MeshCore;
+
+const BAUD_RATE: u32 = 115_200;
+
+pub const USAGE: &str = "\
+Usage: exactly one of the following is required
+  --serial <port>              connect via serial (e.g. /dev/ttyUSB0)
+  --tcp <host:port>             connect via TCP
+  --ble <device-name>           connect via BLE
+  --help                        print this message";
+
+/// Connection parameters selected from the command line, before actually
+/// connecting — kept separate from the I/O so parsing/validation can be
+/// unit tested without a real device.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConnectionArgs {
+    Serial { port: String, baud_rate: u32 },
+    Tcp { host: String, port: u16 },
+    Ble { name: String },
+}
+
+/// Parses connection parameters from `args` (e.g. `env::args().skip(1)`).
+/// Exactly one of `--serial <port>`, `--tcp <host:port>` or
+/// `--ble <name>` must be present; anything else (none, more than one,
+/// unknown flags, missing values) is an error.
+pub fn parse_args<I: IntoIterator<Item = String>>(args: I) -> Result<ConnectionArgs, String> {
+    let mut selected: Option<ConnectionArgs> = None;
+    let mut args = args.into_iter();
+
+    while let Some(flag) = args.next() {
+        let parsed = match flag.as_str() {
+            "--serial" => {
+                let port = args.next().ok_or("--serial requires a <port> argument")?;
+                ConnectionArgs::Serial {
+                    port,
+                    baud_rate: BAUD_RATE,
+                }
+            }
+            "--tcp" => {
+                let value = args.next().ok_or("--tcp requires a <host:port> argument")?;
+                let (host, port) = value
+                    .rsplit_once(':')
+                    .ok_or_else(|| format!("--tcp value must be host:port, got {value:?}"))?;
+                let port: u16 = port
+                    .parse()
+                    .map_err(|_| format!("invalid TCP port {port:?}"))?;
+                ConnectionArgs::Tcp {
+                    host: host.to_string(),
+                    port,
+                }
+            }
+            "--ble" => ConnectionArgs::Ble {
+                name: args
+                    .next()
+                    .ok_or("--ble requires a <device-name> argument")?,
+            },
+            "--help" | "-h" => return Err(USAGE.to_string()),
+            other => return Err(format!("unrecognized argument {other:?}\n\n{USAGE}")),
+        };
+
+        if selected.is_some() {
+            return Err(format!(
+                "only one of --serial, --tcp or --ble may be given\n\n{USAGE}"
+            ));
+        }
+        selected = Some(parsed);
+    }
+
+    selected.ok_or_else(|| format!("one of --serial, --tcp or --ble is required\n\n{USAGE}"))
+}
+
+/// Establishes a MeshCore connection per `args`. Errors clearly if the
+/// matching crate feature wasn't compiled in.
+pub async fn connect(args: &ConnectionArgs) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    match args {
+        ConnectionArgs::Serial { port, baud_rate } => connect_serial(port, *baud_rate).await,
+        ConnectionArgs::Tcp { host, port } => connect_tcp(host, *port).await,
+        ConnectionArgs::Ble { name } => connect_ble(name).await,
+    }
+}
+
+#[cfg(feature = "serial")]
+async fn connect_serial(
+    port: &str,
+    baud_rate: u32,
+) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    println!("Connecting via serial on {port}...");
+    Ok(MeshCore::serial(port, baud_rate).await?)
+}
+#[cfg(not(feature = "serial"))]
+async fn connect_serial(
+    _port: &str,
+    _baud_rate: u32,
+) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    Err(
+        "the \"serial\" feature is not enabled in this build; rebuild with --features serial"
+            .into(),
+    )
+}
+
+#[cfg(feature = "tcp")]
+async fn connect_tcp(host: &str, port: u16) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    println!("Connecting via TCP to {host}:{port}...");
+    Ok(MeshCore::tcp(host, port).await?)
+}
+#[cfg(not(feature = "tcp"))]
+async fn connect_tcp(_host: &str, _port: u16) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    Err("the \"tcp\" feature is not enabled in this build; rebuild with --features tcp".into())
+}
+
+#[cfg(feature = "ble")]
+async fn connect_ble(name: &str) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    println!("Connecting via BLE to {name}...");
+    Ok(MeshCore::ble_connect(name).await?)
+}
+#[cfg(not(feature = "ble"))]
+async fn connect_ble(_name: &str) -> Result<MeshCore, Box<dyn std::error::Error>> {
+    Err("the \"ble\" feature is not enabled in this build; rebuild with --features ble".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn no_arguments_is_an_error() {
+        assert!(parse_args(args(&[])).is_err());
+    }
+
+    #[test]
+    fn serial_requires_an_explicit_port() {
+        assert_eq!(
+            parse_args(args(&["--serial", "/dev/ttyACM0"])).unwrap(),
+            ConnectionArgs::Serial {
+                port: "/dev/ttyACM0".to_string(),
+                baud_rate: BAUD_RATE
+            }
+        );
+        assert!(parse_args(args(&["--serial"])).is_err());
+    }
+
+    #[test]
+    fn tcp_requires_host_and_port() {
+        assert_eq!(
+            parse_args(args(&["--tcp", "192.168.1.50:5000"])).unwrap(),
+            ConnectionArgs::Tcp {
+                host: "192.168.1.50".to_string(),
+                port: 5000
+            }
+        );
+        assert!(parse_args(args(&["--tcp"])).is_err());
+        assert!(parse_args(args(&["--tcp", "no-port-here"])).is_err());
+        assert!(parse_args(args(&["--tcp", "host:not-a-number"])).is_err());
+    }
+
+    #[test]
+    fn ble_requires_a_name() {
+        assert_eq!(
+            parse_args(args(&["--ble", "MeshCore-1234"])).unwrap(),
+            ConnectionArgs::Ble {
+                name: "MeshCore-1234".to_string()
+            }
+        );
+        assert!(parse_args(args(&["--ble"])).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_flags() {
+        assert!(parse_args(args(&["--bogus"])).is_err());
+    }
+
+    #[test]
+    fn rejects_more_than_one_connection_flag() {
+        assert!(parse_args(args(&["--serial", "/dev/ttyUSB0", "--ble", "Foo"])).is_err());
+    }
+}

--- a/examples/rf_packet_monitor.rs
+++ b/examples/rf_packet_monitor.rs
@@ -13,12 +13,17 @@
 //! traffic never triggers it. Use `LogData`, as this example does, to
 //! observe general network activity.
 //!
-//! Usage:
-//!   cargo run --example rf_packet_monitor --features serial -- [serial-port]
+//! Usage: exactly one of the following is required
+//!   cargo run --example rf_packet_monitor --features serial -- --serial <port>
+//!   cargo run --example rf_packet_monitor --features tcp -- --tcp <host:port>
+//!   cargo run --example rf_packet_monitor --features ble -- --ble <device-name>
 
-use meshcore_rs::events::EventPayload;
-use meshcore_rs::{EventType, MeshCore, PayloadType, RouteType};
-use std::env;
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{connect, parse_args, ConnectionArgs};
+use meshcore_rs::events::{EventPayload, MeshPacketHeader, RawAdvertisement};
+use meshcore_rs::{EventType, MeshCoreEvent, PayloadType, RouteType};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,12 +31,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let port = env::args()
-        .nth(1)
-        .unwrap_or_else(|| "/dev/ttyUSB0".to_string());
+    let args = match parse_args(std::env::args().skip(1)) {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(1);
+        }
+    };
 
-    println!("Connecting to MeshCore device on {port}...");
-    let meshcore = MeshCore::serial(&port, 115200).await?;
+    monitor(args).await
+}
+
+/// Connects per `args` and prints every RF packet received until Ctrl+C.
+async fn monitor(args: ConnectionArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let meshcore = connect(&args).await?;
 
     let self_info = meshcore.commands().lock().await.send_appstart().await?;
     println!("Connected to device: {}", self_info.name);
@@ -40,71 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .subscribe(
             EventType::LogData,
             std::collections::HashMap::new(),
-            |event| {
-                if let EventPayload::LogData(log) = event.payload {
-                    println!("RF packet: SNR {:.1} dB, RSSI {} dBm", log.snr, log.rssi);
-
-                    match log.header {
-                        Some(header) => {
-                            println!("  Route: {:?}", header.route_type);
-                            println!("  Payload type: {:?}", header.payload_type);
-                            if !header.path.is_empty() {
-                                // Each hop's hash is `path_hash_size` bytes
-                                // (1-4, encoded in the path descriptor byte)
-                                // — group accordingly rather than dumping a
-                                // flat byte stream, which would be ambiguous
-                                // whenever hash_size != 1.
-                                let hops: Vec<String> = header
-                                    .path
-                                    .chunks(header.path_hash_size as usize)
-                                    .map(|hop| {
-                                        hop.iter().map(|b| format!("{b:02x}")).collect::<String>()
-                                    })
-                                    .collect();
-                                println!(
-                                    "  Path ({} hop(s), {}-byte hash): {}",
-                                    header.path_len,
-                                    header.path_hash_size,
-                                    hops.join(" -> ")
-                                );
-                            }
-
-                            if header.route_type == RouteType::TransportFlood
-                                || header.route_type == RouteType::TransportDirect
-                            {
-                                if let Some(code) = header.transport_code {
-                                    println!("  Transport code: {:02x?}", code);
-                                }
-                            }
-
-                            if header.payload_type == PayloadType::Advert {
-                                if let Some(adv) = log.advertisement {
-                                    println!("  Advertiser: {:02x?}", &adv.public_key[..6]);
-                                    if let Some(name) = &adv.name {
-                                        println!("  Name: {name}");
-                                    }
-                                    if let (Some(lat), Some(lon)) = (adv.lat, adv.lon) {
-                                        println!(
-                                            "  Location: {:.6}, {:.6}",
-                                            lat as f64 / 1_000_000.0,
-                                            lon as f64 / 1_000_000.0
-                                        );
-                                    }
-                                }
-                            } else {
-                                println!("  Payload ({} bytes, opaque): {}", log.payload.len(), {
-                                    log.payload
-                                        .iter()
-                                        .map(|b| format!("{b:02x}"))
-                                        .collect::<String>()
-                                });
-                            }
-                        }
-                        None => println!("  (payload too short to decode a packet header)"),
-                    }
-                    println!();
-                }
-            },
+            print_log_data,
         )
         .await;
 
@@ -115,4 +64,83 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     meshcore.disconnect().await?;
 
     Ok(())
+}
+
+fn print_log_data(event: MeshCoreEvent) {
+    let EventPayload::LogData(log) = event.payload else {
+        return;
+    };
+    println!("RF packet: SNR {:.1} dB, RSSI {} dBm", log.snr, log.rssi);
+
+    let Some(header) = log.header else {
+        println!("  (payload too short to decode a packet header)\n");
+        return;
+    };
+
+    println!("  Route: {:?}", header.route_type);
+    println!("  Payload type: {:?}", header.payload_type);
+    print_path(&header);
+    print_transport_code(&header);
+
+    if header.payload_type == PayloadType::Advert {
+        print_advertisement(log.advertisement.as_ref());
+    } else {
+        print_opaque_payload(&log.payload);
+    }
+    println!();
+}
+
+fn print_path(header: &MeshPacketHeader) {
+    if header.path.is_empty() {
+        return;
+    }
+    // Each hop's hash is `path_hash_size` bytes (1-4, encoded in the path
+    // descriptor byte) — group accordingly rather than dumping a flat byte
+    // stream, which would be ambiguous whenever hash_size != 1.
+    let hops: Vec<String> = header
+        .path
+        .chunks(header.path_hash_size as usize)
+        .map(|hop| hop.iter().map(|b| format!("{b:02x}")).collect::<String>())
+        .collect();
+    println!(
+        "  Path ({} hop(s), {}-byte hash): {}",
+        header.path_len,
+        header.path_hash_size,
+        hops.join(" -> ")
+    );
+}
+
+fn print_transport_code(header: &MeshPacketHeader) {
+    if !matches!(
+        header.route_type,
+        RouteType::TransportFlood | RouteType::TransportDirect
+    ) {
+        return;
+    }
+    let Some(code) = header.transport_code else {
+        return;
+    };
+    println!("  Transport code: {code:02x?}");
+}
+
+fn print_advertisement(adv: Option<&RawAdvertisement>) {
+    let Some(adv) = adv else {
+        return;
+    };
+    println!("  Advertiser: {:02x?}", &adv.public_key[..6]);
+    if let Some(name) = &adv.name {
+        println!("  Name: {name}");
+    }
+    if let (Some(lat), Some(lon)) = (adv.lat, adv.lon) {
+        println!(
+            "  Location: {:.6}, {:.6}",
+            lat as f64 / 1_000_000.0,
+            lon as f64 / 1_000_000.0
+        );
+    }
+}
+
+fn print_opaque_payload(payload: &[u8]) {
+    let hex: String = payload.iter().map(|b| format!("{b:02x}")).collect();
+    println!("  Payload ({} bytes, opaque): {hex}", payload.len());
 }

--- a/examples/rf_packet_monitor.rs
+++ b/examples/rf_packet_monitor.rs
@@ -1,0 +1,118 @@
+//! Example showing how to monitor all RF packets received by the node
+//!
+//! This subscribes to `EventType::LogData`, which the node pushes
+//! automatically for *every* packet its radio receives — regardless of
+//! whether the packet was addressed to it, or of its payload type. It
+//! prints the signal quality (SNR/RSSI), the decoded mesh packet header
+//! (route type, payload type, path), and the advertiser's identity for any
+//! ADVERT packets it overhears.
+//!
+//! `EventType::RawData` is a different, much narrower event: it only fires
+//! for directly-routed, not-yet-seen `RAW_CUSTOM` payloads (sent by another
+//! application via the companion `SEND_RAW_DATA` command) — regular mesh
+//! traffic never triggers it. Use `LogData`, as this example does, to
+//! observe general network activity.
+//!
+//! Usage:
+//!   cargo run --example rf_packet_monitor -- [serial-port]
+
+use meshcore_rs::events::EventPayload;
+use meshcore_rs::{EventType, MeshCore, PayloadType, RouteType};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let port = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/dev/ttyUSB0".to_string());
+
+    println!("Connecting to MeshCore device on {port}...");
+    let meshcore = MeshCore::serial(&port, 115200).await?;
+
+    let self_info = meshcore.commands().lock().await.send_appstart().await?;
+    println!("Connected to device: {}", self_info.name);
+
+    let _sub = meshcore
+        .subscribe(
+            EventType::LogData,
+            std::collections::HashMap::new(),
+            |event| {
+                if let EventPayload::LogData(log) = event.payload {
+                    println!("RF packet: SNR {:.1} dB, RSSI {} dBm", log.snr, log.rssi);
+
+                    match log.header {
+                        Some(header) => {
+                            println!("  Route: {:?}", header.route_type);
+                            println!("  Payload type: {:?}", header.payload_type);
+                            if !header.path.is_empty() {
+                                // Each hop's hash is `path_hash_size` bytes
+                                // (1-4, encoded in the path descriptor byte)
+                                // — group accordingly rather than dumping a
+                                // flat byte stream, which would be ambiguous
+                                // whenever hash_size != 1.
+                                let hops: Vec<String> = header
+                                    .path
+                                    .chunks(header.path_hash_size as usize)
+                                    .map(|hop| {
+                                        hop.iter().map(|b| format!("{b:02x}")).collect::<String>()
+                                    })
+                                    .collect();
+                                println!(
+                                    "  Path ({} hop(s), {}-byte hash): {}",
+                                    header.path_len,
+                                    header.path_hash_size,
+                                    hops.join(" -> ")
+                                );
+                            }
+
+                            if header.route_type == RouteType::TransportFlood
+                                || header.route_type == RouteType::TransportDirect
+                            {
+                                if let Some(code) = header.transport_code {
+                                    println!("  Transport code: {:02x?}", code);
+                                }
+                            }
+
+                            if header.payload_type == PayloadType::Advert {
+                                if let Some(adv) = log.advertisement {
+                                    println!("  Advertiser: {:02x?}", &adv.public_key[..6]);
+                                    if let Some(name) = &adv.name {
+                                        println!("  Name: {name}");
+                                    }
+                                    if let (Some(lat), Some(lon)) = (adv.lat, adv.lon) {
+                                        println!(
+                                            "  Location: {:.6}, {:.6}",
+                                            lat as f64 / 1_000_000.0,
+                                            lon as f64 / 1_000_000.0
+                                        );
+                                    }
+                                }
+                            } else {
+                                println!("  Payload ({} bytes, opaque): {}", log.payload.len(), {
+                                    log.payload
+                                        .iter()
+                                        .map(|b| format!("{b:02x}"))
+                                        .collect::<String>()
+                                });
+                            }
+                        }
+                        None => println!("  (payload too short to decode a packet header)"),
+                    }
+                    println!();
+                }
+            },
+        )
+        .await;
+
+    println!("\nListening for RF packets (press Ctrl+C to exit)...");
+    tokio::signal::ctrl_c().await?;
+
+    println!("\nDisconnecting...");
+    meshcore.disconnect().await?;
+
+    Ok(())
+}

--- a/examples/rf_packet_monitor.rs
+++ b/examples/rf_packet_monitor.rs
@@ -14,7 +14,7 @@
 //! observe general network activity.
 //!
 //! Usage:
-//!   cargo run --example rf_packet_monitor -- [serial-port]
+//!   cargo run --example rf_packet_monitor --features serial -- [serial-port]
 
 use meshcore_rs::events::EventPayload;
 use meshcore_rs::{EventType, MeshCore, PayloadType, RouteType};

--- a/src/events.rs
+++ b/src/events.rs
@@ -562,7 +562,7 @@ pub enum StatsCategory {
 /// node's radio receives (see [`crate::EventType::LogData`]), regardless of
 /// whether the packet was addressed to it. Unlike [`RawPacketData`], no
 /// specific payload type or routing is required to trigger this.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct LogData {
     /// Signal-to-noise ratio (signed byte / 4.0)
     pub snr: f32,
@@ -1522,9 +1522,8 @@ mod tests {
         let _log_data = EventPayload::LogData(LogData {
             snr: 10.5,
             rssi: -80,
-            header: None,
-            advertisement: None,
             payload: vec![0x01, 0x02, 0x03],
+            ..Default::default()
         });
     }
 
@@ -1533,9 +1532,8 @@ mod tests {
         let log_data = LogData {
             snr: 12.25,
             rssi: -75,
-            header: None,
-            advertisement: None,
             payload: vec![0xAA, 0xBB, 0xCC],
+            ..Default::default()
         };
         let cloned = log_data.clone();
         assert_eq!(cloned.snr, 12.25);
@@ -1548,9 +1546,8 @@ mod tests {
         let log_data = LogData {
             snr: 5.5,
             rssi: -90,
-            header: None,
-            advertisement: None,
             payload: vec![0x01, 0x02],
+            ..Default::default()
         };
         let debug_str = format!("{:?}", log_data);
         assert!(debug_str.contains("snr"));
@@ -1565,9 +1562,7 @@ mod tests {
         let log_data = LogData {
             snr: 10.0, // Would be byte value 40
             rssi: -85,
-            header: None,
-            advertisement: None,
-            payload: vec![],
+            ..Default::default()
         };
         assert_eq!(log_data.snr, 10.0);
     }
@@ -1577,22 +1572,15 @@ mod tests {
         let log_data = LogData {
             snr: -5.25, // Would be byte value -21
             rssi: -100,
-            header: None,
-            advertisement: None,
             payload: vec![0x01],
+            ..Default::default()
         };
         assert_eq!(log_data.snr, -5.25);
     }
 
     #[test]
     fn test_log_data_empty_payload() {
-        let log_data = LogData {
-            snr: 0.0,
-            rssi: 0,
-            header: None,
-            advertisement: None,
-            payload: vec![],
-        };
+        let log_data = LogData::default();
         assert!(log_data.payload.is_empty());
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -580,7 +580,7 @@ pub struct LogData {
 }
 
 /// Decoded over-the-air MeshCore packet header, as embedded at the start of
-/// a [`RawPacketData`] capture.
+/// a [`LogData`] capture.
 #[derive(Debug, Clone)]
 pub struct MeshPacketHeader {
     /// Routing strategy used for this packet
@@ -633,20 +633,18 @@ pub struct RawAdvertisement {
 /// traffic (text messages, adverts, telemetry, ...) never triggers this
 /// event; subscribe to [`crate::EventType::LogData`] instead to observe all
 /// received packets.
+///
+/// `payload` is opaque application data, not a mesh packet: the firmware
+/// has already parsed and stripped the mesh header, transport code and path
+/// before delivering it here, so — unlike `LogData` — there is no header to
+/// decode.
 #[derive(Debug, Clone)]
 pub struct RawPacketData {
     /// Signal-to-noise ratio of the received packet
     pub snr: f32,
     /// Received signal strength indicator (dBm)
     pub rssi: i16,
-    /// Decoded mesh packet header, or `None` if the payload was too short
-    /// to contain one
-    pub header: Option<MeshPacketHeader>,
-    /// Advertiser identity, populated when `header.payload_type` is
-    /// [`PayloadType::Advert`] and the inner payload could be decoded
-    pub advertisement: Option<RawAdvertisement>,
-    /// Inner packet payload, after stripping the header and path. Opaque
-    /// (and typically encrypted) for message and channel payload types.
+    /// Opaque `RAW_CUSTOM` application payload.
     pub payload: Vec<u8>,
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, RwLock};
 
+use crate::packets::{PayloadType, RouteType};
 use crate::CHANNEL_SECRET_LEN;
 
 /// Event types emitted by MeshCore
@@ -147,8 +148,10 @@ pub enum EventPayload {
     Stats(StatsData),
     /// AutoAdd config
     AutoAddConfig { flags: u8 },
-    /// RF log data
+    /// RF log data: every packet the radio receives (see [`LogData`])
     LogData(LogData),
+    /// Custom raw-data packet addressed to this node (see [`RawPacketData`])
+    RawData(RawPacketData),
 }
 
 /// Contact information
@@ -555,14 +558,95 @@ pub enum StatsCategory {
     Packets,
 }
 
-/// RF log data from the device
+/// RF log data from the device: pushed automatically for *every* packet the
+/// node's radio receives (see [`crate::EventType::LogData`]), regardless of
+/// whether the packet was addressed to it. Unlike [`RawPacketData`], no
+/// specific payload type or routing is required to trigger this.
 #[derive(Debug, Clone)]
 pub struct LogData {
     /// Signal-to-noise ratio (signed byte / 4.0)
     pub snr: f32,
     /// Received signal strength indicator (dBm)
     pub rssi: i16,
-    /// Raw RF payload
+    /// Decoded mesh packet header, or `None` if the payload was too short
+    /// to contain one
+    pub header: Option<MeshPacketHeader>,
+    /// Advertiser identity, populated when `header.payload_type` is
+    /// [`PayloadType::Advert`] and the inner payload could be decoded
+    pub advertisement: Option<RawAdvertisement>,
+    /// Inner packet payload, after stripping the header and path. Opaque
+    /// (and typically encrypted) for message and channel payload types.
+    pub payload: Vec<u8>,
+}
+
+/// Decoded over-the-air MeshCore packet header, as embedded at the start of
+/// a [`RawPacketData`] capture.
+#[derive(Debug, Clone)]
+pub struct MeshPacketHeader {
+    /// Routing strategy used for this packet
+    pub route_type: RouteType,
+    /// Type of the inner payload
+    pub payload_type: PayloadType,
+    /// Payload format version (2-bit field)
+    pub payload_version: u8,
+    /// Transport code, present only for [`RouteType::TransportFlood`] and
+    /// [`RouteType::TransportDirect`] routes
+    pub transport_code: Option<[u8; 4]>,
+    /// Number of hops recorded in `path`
+    pub path_len: u8,
+    /// Size in bytes of each hop hash in `path` (1-4)
+    pub path_hash_size: u8,
+    /// Raw hop hashes, `path_len * path_hash_size` bytes
+    pub path: Vec<u8>,
+}
+
+/// Node identity broadcast in a raw ADVERT payload overheard on the mesh.
+///
+/// Unlike [`AdvertisementData`] (the companion's own summarized push, keyed
+/// by a 6-byte prefix), this carries the full advertisement as it appears
+/// on air, including the advertiser's full public key and signature.
+#[derive(Debug, Clone)]
+pub struct RawAdvertisement {
+    /// Advertiser's full 32-byte public key
+    pub public_key: [u8; 32],
+    /// Advertisement timestamp (seconds)
+    pub timestamp: u32,
+    /// Signature over the advertisement (64 bytes)
+    pub signature: [u8; 64],
+    /// Advertiser type (bits 0-3 of the flags byte; see [`Contact::contact_type`])
+    pub adv_type: u8,
+    /// Latitude in microdegrees, if the advertiser included its location
+    pub lat: Option<i32>,
+    /// Longitude in microdegrees, if the advertiser included its location
+    pub lon: Option<i32>,
+    /// Advertised name, if included
+    pub name: Option<String>,
+}
+
+/// Raw custom-data packet received by the node, pushed as
+/// [`crate::EventType::RawData`].
+///
+/// Unlike [`LogData`], this is *not* a general packet monitor: the firmware
+/// only emits it for directly-routed, not-yet-seen packets whose payload
+/// type is `RAW_CUSTOM` — i.e. packets sent by another application via the
+/// companion `SEND_RAW_DATA` command, addressed to this node. Regular mesh
+/// traffic (text messages, adverts, telemetry, ...) never triggers this
+/// event; subscribe to [`crate::EventType::LogData`] instead to observe all
+/// received packets.
+#[derive(Debug, Clone)]
+pub struct RawPacketData {
+    /// Signal-to-noise ratio of the received packet
+    pub snr: f32,
+    /// Received signal strength indicator (dBm)
+    pub rssi: i16,
+    /// Decoded mesh packet header, or `None` if the payload was too short
+    /// to contain one
+    pub header: Option<MeshPacketHeader>,
+    /// Advertiser identity, populated when `header.payload_type` is
+    /// [`PayloadType::Advert`] and the inner payload could be decoded
+    pub advertisement: Option<RawAdvertisement>,
+    /// Inner packet payload, after stripping the header and path. Opaque
+    /// (and typically encrypted) for message and channel payload types.
     pub payload: Vec<u8>,
 }
 
@@ -1438,6 +1522,8 @@ mod tests {
         let _log_data = EventPayload::LogData(LogData {
             snr: 10.5,
             rssi: -80,
+            header: None,
+            advertisement: None,
             payload: vec![0x01, 0x02, 0x03],
         });
     }
@@ -1447,6 +1533,8 @@ mod tests {
         let log_data = LogData {
             snr: 12.25,
             rssi: -75,
+            header: None,
+            advertisement: None,
             payload: vec![0xAA, 0xBB, 0xCC],
         };
         let cloned = log_data.clone();
@@ -1460,6 +1548,8 @@ mod tests {
         let log_data = LogData {
             snr: 5.5,
             rssi: -90,
+            header: None,
+            advertisement: None,
             payload: vec![0x01, 0x02],
         };
         let debug_str = format!("{:?}", log_data);
@@ -1475,6 +1565,8 @@ mod tests {
         let log_data = LogData {
             snr: 10.0, // Would be byte value 40
             rssi: -85,
+            header: None,
+            advertisement: None,
             payload: vec![],
         };
         assert_eq!(log_data.snr, 10.0);
@@ -1485,6 +1577,8 @@ mod tests {
         let log_data = LogData {
             snr: -5.25, // Would be byte value -21
             rssi: -100,
+            header: None,
+            advertisement: None,
             payload: vec![0x01],
         };
         assert_eq!(log_data.snr, -5.25);
@@ -1495,6 +1589,8 @@ mod tests {
         let log_data = LogData {
             snr: 0.0,
             rssi: 0,
+            header: None,
+            advertisement: None,
             payload: vec![],
         };
         assert!(log_data.payload.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub use events::{
     MsgSentInfo, Subscription,
 };
 pub use meshcore::MeshCore;
-pub use packets::{AnonReqType, BinaryReqType, ControlType, PacketType};
+pub use packets::{AnonReqType, BinaryReqType, ControlType, PacketType, PayloadType, RouteType};
 
 /// Result type alias using the library's Error type
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -187,6 +187,87 @@ impl From<u8> for ControlType {
     }
 }
 
+/// Routing strategy of a MeshCore over-the-air packet, encoded in bits 0-1
+/// of the packet header byte carried inside raw packet captures (see
+/// [`crate::events::MeshPacketHeader`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum RouteType {
+    /// Flood-routed packet that also carries a transport code
+    TransportFlood = 0,
+    /// Flood-routed packet
+    Flood = 1,
+    /// Directly-routed packet along an explicit path
+    Direct = 2,
+    /// Directly-routed packet that also carries a transport code
+    TransportDirect = 3,
+}
+
+impl From<u8> for RouteType {
+    fn from(value: u8) -> Self {
+        match value & 0x03 {
+            0 => RouteType::TransportFlood,
+            1 => RouteType::Flood,
+            2 => RouteType::Direct,
+            _ => RouteType::TransportDirect,
+        }
+    }
+}
+
+/// Payload type of a MeshCore over-the-air packet, encoded in bits 2-5 of
+/// the packet header byte carried inside raw packet captures (see
+/// [`crate::events::MeshPacketHeader`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum PayloadType {
+    /// Request payload
+    Req = 0,
+    /// Response payload
+    Response = 1,
+    /// Direct text message
+    TextMsg = 2,
+    /// Acknowledgement
+    Ack = 3,
+    /// Node advertisement (broadcast identity)
+    Advert = 4,
+    /// Group/channel text message
+    GroupText = 5,
+    /// Group/channel data
+    GroupData = 6,
+    /// Anonymous request
+    AnonReq = 7,
+    /// Path/route information
+    Path = 8,
+    /// Trace packet
+    Trace = 9,
+    /// Multipart message fragment
+    Multipart = 10,
+    /// Control packet
+    Control = 11,
+    /// Unrecognized payload type
+    Unknown = 0xFF,
+}
+
+impl From<u8> for PayloadType {
+    fn from(value: u8) -> Self {
+        match value & 0x0F {
+            0 => PayloadType::Req,
+            1 => PayloadType::Response,
+            2 => PayloadType::TextMsg,
+            3 => PayloadType::Ack,
+            4 => PayloadType::Advert,
+            5 => PayloadType::GroupText,
+            6 => PayloadType::GroupData,
+            7 => PayloadType::AnonReq,
+            8 => PayloadType::Path,
+            9 => PayloadType::Trace,
+            10 => PayloadType::Multipart,
+            11 => PayloadType::Control,
+            _ => PayloadType::Unknown,
+        }
+    }
+}
+
 /// Frame start marker byte (app → radio, commands)
 pub const FRAME_START: u8 = 0x3c;
 
@@ -339,5 +420,48 @@ mod tests {
         let p1 = PacketType::SelfInfo;
         let p2 = p1;
         assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_route_type_from_u8() {
+        assert_eq!(RouteType::from(0), RouteType::TransportFlood);
+        assert_eq!(RouteType::from(1), RouteType::Flood);
+        assert_eq!(RouteType::from(2), RouteType::Direct);
+        assert_eq!(RouteType::from(3), RouteType::TransportDirect);
+    }
+
+    #[test]
+    fn test_route_type_from_u8_masks_upper_bits() {
+        // Only bits 0-1 are significant; upper bits must be ignored.
+        assert_eq!(RouteType::from(0b1111_1100), RouteType::TransportFlood);
+        assert_eq!(RouteType::from(0b1111_1101), RouteType::Flood);
+    }
+
+    #[test]
+    fn test_payload_type_from_u8() {
+        assert_eq!(PayloadType::from(0), PayloadType::Req);
+        assert_eq!(PayloadType::from(1), PayloadType::Response);
+        assert_eq!(PayloadType::from(2), PayloadType::TextMsg);
+        assert_eq!(PayloadType::from(3), PayloadType::Ack);
+        assert_eq!(PayloadType::from(4), PayloadType::Advert);
+        assert_eq!(PayloadType::from(5), PayloadType::GroupText);
+        assert_eq!(PayloadType::from(6), PayloadType::GroupData);
+        assert_eq!(PayloadType::from(7), PayloadType::AnonReq);
+        assert_eq!(PayloadType::from(8), PayloadType::Path);
+        assert_eq!(PayloadType::from(9), PayloadType::Trace);
+        assert_eq!(PayloadType::from(10), PayloadType::Multipart);
+        assert_eq!(PayloadType::from(11), PayloadType::Control);
+    }
+
+    #[test]
+    fn test_payload_type_from_u8_unknown() {
+        assert_eq!(PayloadType::from(12), PayloadType::Unknown);
+        assert_eq!(PayloadType::from(15), PayloadType::Unknown);
+    }
+
+    #[test]
+    fn test_payload_type_from_u8_masks_upper_bits() {
+        // Only bits 0-3 are significant; upper bits must be ignored.
+        assert_eq!(PayloadType::from(0b1111_0100), PayloadType::Advert);
     }
 }

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -244,6 +244,9 @@ pub enum PayloadType {
     Multipart = 10,
     /// Control packet
     Control = 11,
+    /// Custom packet as raw bytes, for applications with custom encryption
+    /// and payloads (see `RAW_DATA`/`SEND_RAW_DATA`)
+    RawCustom = 0x0F,
     /// Unrecognized payload type
     Unknown = 0xFF,
 }
@@ -263,6 +266,7 @@ impl From<u8> for PayloadType {
             9 => PayloadType::Trace,
             10 => PayloadType::Multipart,
             11 => PayloadType::Control,
+            15 => PayloadType::RawCustom,
             _ => PayloadType::Unknown,
         }
     }
@@ -451,12 +455,16 @@ mod tests {
         assert_eq!(PayloadType::from(9), PayloadType::Trace);
         assert_eq!(PayloadType::from(10), PayloadType::Multipart);
         assert_eq!(PayloadType::from(11), PayloadType::Control);
+        assert_eq!(PayloadType::from(15), PayloadType::RawCustom);
     }
 
     #[test]
     fn test_payload_type_from_u8_unknown() {
+        // 12-14 are still reserved/unassigned in the firmware; only 15
+        // (RAW_CUSTOM) has a defined meaning.
         assert_eq!(PayloadType::from(12), PayloadType::Unknown);
-        assert_eq!(PayloadType::from(15), PayloadType::Unknown);
+        assert_eq!(PayloadType::from(13), PayloadType::Unknown);
+        assert_eq!(PayloadType::from(14), PayloadType::Unknown);
     }
 
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -668,7 +668,9 @@ pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
 
     let mut offset = MIN_LEN;
 
-    let (lat, lon) = if flags & 0x10 != 0 && offset + 8 <= data.len() {
+    let (lat, lon) = if flags & 0x10 != 0 {
+        // A declared location that does not fit means the capture is
+        // truncated; every later offset would be wrong.
         let lat = read_i32_le(data, offset).ok()?;
         let lon = read_i32_le(data, offset + 4).ok()?;
         offset += 8;
@@ -1457,6 +1459,19 @@ mod tests {
     #[test]
     fn test_parse_raw_advertisement_too_short() {
         let data = vec![0u8; 50];
+        assert!(parse_raw_advertisement(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_advertisement_truncated_location_fails() {
+        // flags: has location (0x10) and name (0x80), but only 4 trailing
+        // bytes — not enough for the 8-byte lat/lon. Must be rejected as a
+        // parse failure rather than silently misreading the name from
+        // inside the truncated location bytes.
+        let mut data = vec![0u8; 101];
+        data[100] = 0x90;
+        data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
+
         assert!(parse_raw_advertisement(&data).is_none());
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -607,13 +607,9 @@ const PAYLOAD_VERSION_SHIFT: u8 = 6;
 /// packet payload, or `None` if `data` is too short to contain a header and
 /// a path byte.
 pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])> {
-    if data.is_empty() {
-        return None;
-    }
-
     // Header byte layout: bits 0-1 = route type, bits 2-5 = payload type,
     // bits 6-7 = payload format version.
-    let header_byte = data[0];
+    let header_byte = *data.first()?;
     let route_type = RouteType::from(header_byte);
     let payload_type = PayloadType::from(header_byte >> PAYLOAD_TYPE_SHIFT);
     let payload_version = (header_byte & 0xc0) >> PAYLOAD_VERSION_SHIFT;
@@ -631,10 +627,7 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
         None
     };
 
-    if offset >= data.len() {
-        return None;
-    }
-    let path_byte = data[offset];
+    let path_byte = *data.get(offset)?;
     offset += 1;
 
     let path_hash_size = ((path_byte & 0xC0) >> 6) + 1;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -2,9 +2,10 @@
 
 use crate::error::Error;
 use crate::events::{
-    AclEntry, ChannelMessage, Contact, ContactMessage, DeviceInfoData, MmaEntry, Neighbour,
-    NeighboursData, SelfInfo, StatusData,
+    AclEntry, ChannelMessage, Contact, ContactMessage, DeviceInfoData, MeshPacketHeader, MmaEntry,
+    Neighbour, NeighboursData, RawAdvertisement, SelfInfo, StatusData,
 };
+use crate::packets::{PayloadType, RouteType};
 use crate::Result;
 
 /// Read a little-endian u16 from a byte slice
@@ -589,6 +590,115 @@ pub fn parse_mma(data: &[u8]) -> Vec<MmaEntry> {
     }
 
     entries
+}
+
+/// Parse the MeshCore over-the-air packet header (route type, payload type
+/// and path) from the start of a buffer, as embedded in RAW_DATA/LOG_DATA
+/// captures.
+///
+/// Returns the decoded header together with the remaining, unparsed inner
+/// packet payload, or `None` if `data` is too short to contain a header and
+/// a path byte.
+pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])> {
+    if data.is_empty() {
+        return None;
+    }
+
+    let header_byte = data[0];
+    let route_type = RouteType::from(header_byte);
+    let payload_type = PayloadType::from(header_byte >> 2);
+    let payload_version = (header_byte & 0xc0) >> 6;
+
+    let mut offset = 1;
+
+    let transport_code = if matches!(
+        route_type,
+        RouteType::TransportFlood | RouteType::TransportDirect
+    ) {
+        let code: [u8; 4] = read_bytes(data, offset).ok()?;
+        offset += 4;
+        Some(code)
+    } else {
+        None
+    };
+
+    if offset >= data.len() {
+        return None;
+    }
+    let path_byte = data[offset];
+    offset += 1;
+
+    let path_hash_size = ((path_byte & 0xC0) >> 6) + 1;
+    let path_len = path_byte & 0x3F;
+    let path_bytes_len = path_len as usize * path_hash_size as usize;
+
+    if offset + path_bytes_len > data.len() {
+        return None;
+    }
+    let path = data[offset..offset + path_bytes_len].to_vec();
+    offset += path_bytes_len;
+
+    let header = MeshPacketHeader {
+        route_type,
+        payload_type,
+        payload_version,
+        transport_code,
+        path_len,
+        path_hash_size,
+        path,
+    };
+
+    Some((header, &data[offset..]))
+}
+
+/// Parse a raw ADVERT payload (public key, timestamp, signature, flags and
+/// optional location/name), as carried by a [`PayloadType::Advert`] packet.
+pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
+    // public_key(32) + timestamp(4) + signature(64) + flags(1)
+    const MIN_LEN: usize = 32 + 4 + 64 + 1;
+    if data.len() < MIN_LEN {
+        return None;
+    }
+
+    let public_key: [u8; 32] = read_bytes(data, 0).ok()?;
+    let timestamp = read_u32_le(data, 32).ok()?;
+    let signature: [u8; 64] = read_bytes(data, 36).ok()?;
+    let flags = data[100];
+    let adv_type = flags & 0x0F;
+
+    let mut offset = MIN_LEN;
+
+    let (lat, lon) = if flags & 0x10 != 0 && offset + 8 <= data.len() {
+        let lat = read_i32_le(data, offset).ok()?;
+        let lon = read_i32_le(data, offset + 4).ok()?;
+        offset += 8;
+        (Some(lat), Some(lon))
+    } else {
+        (None, None)
+    };
+
+    if flags & 0x20 != 0 {
+        offset += 2; // feature1, not currently decoded
+    }
+    if flags & 0x40 != 0 {
+        offset += 2; // feature2, not currently decoded
+    }
+
+    let name = if flags & 0x80 != 0 && data.len() > offset {
+        Some(read_string(data, offset, data.len() - offset))
+    } else {
+        None
+    };
+
+    Some(RawAdvertisement {
+        public_key,
+        timestamp,
+        signature,
+        adv_type,
+        lat,
+        lon,
+        name,
+    })
 }
 
 /// Encode coordinates as microdegrees
@@ -1235,5 +1345,118 @@ mod tests {
         let info = parse_device_info(&data);
         // 200 * 2 would overflow u8, but we use saturating_mul
         assert_eq!(info.max_contacts, Some(255)); // Saturated
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_flood_no_transport() {
+        // route=Flood(1), payload_type=TextMsg(2), payload_ver=0
+        let header_byte: u8 = (2 << 2) | 1;
+        // path_hash_size=1 (bits 6-7 = 0b00), path_len=2
+        let path_byte = 0b00_000010;
+        let data = [header_byte, path_byte, 0xAA, 0xBB, 0xCC, 0xDD];
+
+        let (header, remaining) = parse_mesh_packet_header(&data).unwrap();
+        assert_eq!(header.route_type, RouteType::Flood);
+        assert_eq!(header.payload_type, PayloadType::TextMsg);
+        assert_eq!(header.payload_version, 0);
+        assert!(header.transport_code.is_none());
+        assert_eq!(header.path_len, 2);
+        assert_eq!(header.path_hash_size, 1);
+        assert_eq!(header.path, vec![0xAA, 0xBB]);
+        assert_eq!(remaining, &[0xCC, 0xDD]);
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_with_transport_code() {
+        // route=TransportFlood(0), payload_type=Advert(4), payload_ver=1
+        let header_byte = (1u8 << 6) | (4 << 2);
+        // path_hash_size=2 (bits 6-7 = 0b01 -> +1), path_len=1
+        let path_byte = 0b01_000001;
+        let data = [
+            header_byte, // header
+            0x11,
+            0x22,
+            0x33,
+            0x44,      // transport code
+            path_byte, // path descriptor
+            0x01,
+            0x02, // path (1 hop * 2 bytes)
+            0x99, // remaining inner payload
+        ];
+
+        let (header, remaining) = parse_mesh_packet_header(&data).unwrap();
+        assert_eq!(header.route_type, RouteType::TransportFlood);
+        assert_eq!(header.payload_type, PayloadType::Advert);
+        assert_eq!(header.payload_version, 1);
+        assert_eq!(header.transport_code, Some([0x11, 0x22, 0x33, 0x44]));
+        assert_eq!(header.path_len, 1);
+        assert_eq!(header.path_hash_size, 2);
+        assert_eq!(header.path, vec![0x01, 0x02]);
+        assert_eq!(remaining, &[0x99]);
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_empty() {
+        assert!(parse_mesh_packet_header(&[]).is_none());
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_missing_path_byte() {
+        // Direct route, no transport code, but no path byte follows
+        let data = [2u8];
+        assert!(parse_mesh_packet_header(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_path_truncated() {
+        // path_len=5, path_hash_size=1 declared, but no path bytes follow
+        let data = [1u8, 0b00_000101];
+        assert!(parse_mesh_packet_header(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_mesh_packet_header_missing_transport_code() {
+        // TransportDirect route requires a 4-byte transport code that isn't present
+        let data = [3u8, 0x11, 0x22];
+        assert!(parse_mesh_packet_header(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_advertisement_with_name() {
+        let mut data = vec![0u8; 101];
+        data[0..6].copy_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]); // pubkey prefix
+        data[32..36].copy_from_slice(&123456u32.to_le_bytes()); // timestamp
+        data[36..40].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // signature prefix
+        data[100] = 0x80; // flags: has name only
+        data.extend_from_slice(b"Node1");
+
+        let adv = parse_raw_advertisement(&data).unwrap();
+        assert_eq!(&adv.public_key[0..6], &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(adv.timestamp, 123456);
+        assert_eq!(&adv.signature[0..4], &[0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(adv.adv_type, 0);
+        assert!(adv.lat.is_none());
+        assert!(adv.lon.is_none());
+        assert_eq!(adv.name.as_deref(), Some("Node1"));
+    }
+
+    #[test]
+    fn test_parse_raw_advertisement_with_location() {
+        let mut data = vec![0u8; 101];
+        data[100] = 0x11; // flags: adv_type=1, has location
+        data.extend_from_slice(&37774900i32.to_le_bytes());
+        data.extend_from_slice(&(-122419400i32).to_le_bytes());
+
+        let adv = parse_raw_advertisement(&data).unwrap();
+        assert_eq!(adv.adv_type, 1);
+        assert_eq!(adv.lat, Some(37774900));
+        assert_eq!(adv.lon, Some(-122419400));
+        assert!(adv.name.is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_advertisement_too_short() {
+        let data = vec![0u8; 50];
+        assert!(parse_raw_advertisement(&data).is_none());
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1457,6 +1457,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_raw_advertisement_skips_unknown_feature_blocks() {
+        // flags: feature1 (0x20) + feature2 (0x40) + name (0x80), no
+        // location. Each feature block is 2 bytes we don't decode but must
+        // still skip correctly, otherwise the name would be read from the
+        // wrong offset (garbled, or misaligned into the feature bytes).
+        let mut data = vec![0u8; 101];
+        data[100] = 0x20 | 0x40 | 0x80;
+        data.extend_from_slice(&[0xAA, 0xAA]); // feature1, skipped
+        data.extend_from_slice(&[0xBB, 0xBB]); // feature2, skipped
+        data.extend_from_slice(b"Node2");
+
+        let adv = parse_raw_advertisement(&data).unwrap();
+        assert!(adv.lat.is_none());
+        assert!(adv.lon.is_none());
+        assert_eq!(adv.name.as_deref(), Some("Node2"));
+    }
+
+    #[test]
     fn test_parse_raw_advertisement_too_short() {
         let data = vec![0u8; 50];
         assert!(parse_raw_advertisement(&data).is_none());

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -599,6 +599,15 @@ const PAYLOAD_TYPE_SHIFT: u8 = 2;
 /// byte.
 const PAYLOAD_VERSION_SHIFT: u8 = 6;
 
+/// Length of the packet header byte itself.
+const HEADER_BYTE_LEN: usize = 1;
+/// Length of the optional transport code, present only for
+/// `TransportFlood`/`TransportDirect` routes.
+const TRANSPORT_CODE_LEN: usize = 4;
+/// Length of the path-length/hash-size byte that follows the header (and
+/// the transport code, if present).
+const PATH_BYTE_LEN: usize = 1;
+
 /// Parse the MeshCore over-the-air packet header (route type, payload type
 /// and path) from the start of a buffer, as embedded in RAW_DATA/LOG_DATA
 /// captures.
@@ -614,31 +623,35 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
     let payload_type = PayloadType::from(header_byte >> PAYLOAD_TYPE_SHIFT);
     let payload_version = (header_byte & 0xc0) >> PAYLOAD_VERSION_SHIFT;
 
-    let mut offset = 1;
+    let mut offset = HEADER_BYTE_LEN;
 
     let transport_code = if matches!(
         route_type,
         RouteType::TransportFlood | RouteType::TransportDirect
     ) {
         let code: [u8; 4] = read_bytes(data, offset).ok()?;
-        offset += 4;
+        offset = offset.checked_add(TRANSPORT_CODE_LEN)?;
         Some(code)
     } else {
         None
     };
 
     let path_byte = *data.get(offset)?;
-    offset += 1;
+    offset = offset.checked_add(PATH_BYTE_LEN)?;
 
-    let path_hash_size = ((path_byte & 0xC0) >> 6) + 1;
+    // path_hash_size is bounded to 1-4 (2-bit field + 1) and path_len to
+    // 0-63 (6-bit field), so their product is bounded to 252, far under
+    // usize::MAX -- neither line below can overflow.
+    let path_hash_size = ((path_byte & 0xC0) >> 6) + 1; // jonesy:allow(overflow)
     let path_len = path_byte & 0x3F;
-    let path_bytes_len = path_len as usize * path_hash_size as usize;
+    let path_bytes_len = path_len as usize * path_hash_size as usize; // jonesy:allow(overflow)
 
-    if offset + path_bytes_len > data.len() {
+    let path_end = offset.checked_add(path_bytes_len)?;
+    if path_end > data.len() {
         return None;
     }
-    let path = data[offset..offset + path_bytes_len].to_vec();
-    offset += path_bytes_len;
+    let path = data[offset..path_end].to_vec(); // jonesy:allow(bounds) -- checked above
+    offset = path_end;
 
     let header = MeshPacketHeader {
         route_type,
@@ -685,7 +698,7 @@ pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
     let public_key: [u8; 32] = read_bytes(data, 0).ok()?;
     let timestamp = read_u32_le(data, TIMESTAMP_OFFSET).ok()?;
     let signature: [u8; 64] = read_bytes(data, SIGNATURE_OFFSET).ok()?;
-    let flags = data[FLAGS_OFFSET];
+    let flags = *data.get(FLAGS_OFFSET)?;
     let adv_type = flags & FLAG_ADV_TYPE_MASK;
 
     let mut offset = MIN_LEN;
@@ -693,22 +706,24 @@ pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
     let (lat, lon) = if flags & FLAG_HAS_LOCATION != 0 {
         // A declared location that does not fit means the capture is
         // truncated; every later offset would be wrong.
+        let lon_offset = offset.checked_add(4)?;
         let lat = read_i32_le(data, offset).ok()?;
-        let lon = read_i32_le(data, offset + 4).ok()?;
-        offset += LOCATION_LEN;
+        let lon = read_i32_le(data, lon_offset).ok()?;
+        offset = offset.checked_add(LOCATION_LEN)?;
         (Some(lat), Some(lon))
     } else {
         (None, None)
     };
 
     if flags & FLAG_HAS_FEATURE1 != 0 {
-        offset += FEATURE_BLOCK_LEN;
+        offset = offset.checked_add(FEATURE_BLOCK_LEN)?;
     }
     if flags & FLAG_HAS_FEATURE2 != 0 {
-        offset += FEATURE_BLOCK_LEN;
+        offset = offset.checked_add(FEATURE_BLOCK_LEN)?;
     }
 
     let name = if flags & FLAG_HAS_NAME != 0 && data.len() > offset {
+        // jonesy:allow(overflow) -- guarded by `data.len() > offset` above
         Some(read_string(data, offset, data.len() - offset))
     } else {
         None

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -592,6 +592,13 @@ pub fn parse_mma(data: &[u8]) -> Vec<MmaEntry> {
     entries
 }
 
+/// Bit position of the payload type field within a packet header byte (see
+/// `parse_mesh_packet_header`); route type occupies bits 0-1 below it.
+const PAYLOAD_TYPE_SHIFT: u8 = 2;
+/// Bit position of the payload format version field within a packet header
+/// byte.
+const PAYLOAD_VERSION_SHIFT: u8 = 6;
+
 /// Parse the MeshCore over-the-air packet header (route type, payload type
 /// and path) from the start of a buffer, as embedded in RAW_DATA/LOG_DATA
 /// captures.
@@ -608,8 +615,8 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
     // bits 6-7 = payload format version.
     let header_byte = data[0];
     let route_type = RouteType::from(header_byte);
-    let payload_type = PayloadType::from(header_byte >> 2);
-    let payload_version = (header_byte & 0xc0) >> 6;
+    let payload_type = PayloadType::from(header_byte >> PAYLOAD_TYPE_SHIFT);
+    let payload_version = (header_byte & 0xc0) >> PAYLOAD_VERSION_SHIFT;
 
     let mut offset = 1;
 
@@ -653,29 +660,31 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
     Some((header, &data[offset..]))
 }
 
+const PUBLIC_KEY_LEN: usize = 32;
+const TIMESTAMP_LEN: usize = 4;
+const SIGNATURE_LEN: usize = 64;
+const FLAGS_LEN: usize = 1;
+
+const TIMESTAMP_OFFSET: usize = PUBLIC_KEY_LEN;
+const SIGNATURE_OFFSET: usize = TIMESTAMP_OFFSET + TIMESTAMP_LEN;
+const FLAGS_OFFSET: usize = SIGNATURE_OFFSET + SIGNATURE_LEN;
+/// Minimum length of a raw ADVERT payload (public key + timestamp +
+/// signature + flags), before any of the optional trailing fields.
+const MIN_LEN: usize = FLAGS_OFFSET + FLAGS_LEN;
+
+// Flag bits of the byte at FLAGS_OFFSET.
+const FLAG_ADV_TYPE_MASK: u8 = 0x0F; // advertiser type (see Contact::contact_type)
+const FLAG_HAS_LOCATION: u8 = 0x10; // 8 bytes: lat (i32 LE) + lon (i32 LE)
+const FLAG_HAS_FEATURE1: u8 = 0x20; // 2 bytes, not currently decoded
+const FLAG_HAS_FEATURE2: u8 = 0x40; // 2 bytes, not currently decoded
+const FLAG_HAS_NAME: u8 = 0x80; // remaining bytes, UTF-8 name
+
+const LOCATION_LEN: usize = 8;
+const FEATURE_BLOCK_LEN: usize = 2;
+
 /// Parse a raw ADVERT payload (public key, timestamp, signature, flags and
 /// optional location/name), as carried by a [`PayloadType::Advert`] packet.
 pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
-    const PUBLIC_KEY_LEN: usize = 32;
-    const TIMESTAMP_LEN: usize = 4;
-    const SIGNATURE_LEN: usize = 64;
-    const FLAGS_LEN: usize = 1;
-
-    const TIMESTAMP_OFFSET: usize = PUBLIC_KEY_LEN;
-    const SIGNATURE_OFFSET: usize = TIMESTAMP_OFFSET + TIMESTAMP_LEN;
-    const FLAGS_OFFSET: usize = SIGNATURE_OFFSET + SIGNATURE_LEN;
-    const MIN_LEN: usize = FLAGS_OFFSET + FLAGS_LEN;
-
-    // Flag bits of the byte at FLAGS_OFFSET.
-    const FLAG_ADV_TYPE_MASK: u8 = 0x0F; // advertiser type (see Contact::contact_type)
-    const FLAG_HAS_LOCATION: u8 = 0x10; // 8 bytes: lat (i32 LE) + lon (i32 LE)
-    const FLAG_HAS_FEATURE1: u8 = 0x20; // 2 bytes, not currently decoded
-    const FLAG_HAS_FEATURE2: u8 = 0x40; // 2 bytes, not currently decoded
-    const FLAG_HAS_NAME: u8 = 0x80; // remaining bytes, UTF-8 name
-
-    const LOCATION_LEN: usize = 8;
-    const FEATURE_BLOCK_LEN: usize = 2;
-
     if data.len() < MIN_LEN {
         return None;
     }
@@ -1371,8 +1380,9 @@ mod tests {
 
     #[test]
     fn test_parse_mesh_packet_header_flood_no_transport() {
-        // route=Flood(1), payload_type=TextMsg(2), payload_ver=0
-        let header_byte: u8 = (2 << 2) | 1;
+        // route=Flood, payload_type=TextMsg, payload_ver=0
+        let header_byte: u8 =
+            ((PayloadType::TextMsg as u8) << PAYLOAD_TYPE_SHIFT) | RouteType::Flood as u8;
         // path_hash_size=1 (bits 6-7 = 0b00), path_len=2
         let path_byte = 0b00_000010;
         let data = [header_byte, path_byte, 0xAA, 0xBB, 0xCC, 0xDD];
@@ -1390,8 +1400,10 @@ mod tests {
 
     #[test]
     fn test_parse_mesh_packet_header_with_transport_code() {
-        // route=TransportFlood(0), payload_type=Advert(4), payload_ver=1
-        let header_byte = (1u8 << 6) | (4 << 2);
+        // route=TransportFlood, payload_type=Advert, payload_ver=1
+        let header_byte = (1u8 << PAYLOAD_VERSION_SHIFT)
+            | ((PayloadType::Advert as u8) << PAYLOAD_TYPE_SHIFT)
+            | RouteType::TransportFlood as u8;
         // path_hash_size=2 (bits 6-7 = 0b01 -> +1), path_len=1
         let path_byte = 0b01_000001;
         let data = [
@@ -1445,11 +1457,11 @@ mod tests {
 
     #[test]
     fn test_parse_raw_advertisement_with_name() {
-        let mut data = vec![0u8; 101];
+        let mut data = vec![0u8; MIN_LEN];
         data[0..6].copy_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]); // pubkey prefix
-        data[32..36].copy_from_slice(&123456u32.to_le_bytes()); // timestamp
-        data[36..40].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // signature prefix
-        data[100] = 0x80; // flags: has name only
+        data[TIMESTAMP_OFFSET..TIMESTAMP_OFFSET + 4].copy_from_slice(&123456u32.to_le_bytes());
+        data[SIGNATURE_OFFSET..SIGNATURE_OFFSET + 4].copy_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // signature prefix
+        data[FLAGS_OFFSET] = FLAG_HAS_NAME;
         data.extend_from_slice(b"Node1");
 
         let adv = parse_raw_advertisement(&data).unwrap();
@@ -1464,8 +1476,8 @@ mod tests {
 
     #[test]
     fn test_parse_raw_advertisement_with_location() {
-        let mut data = vec![0u8; 101];
-        data[100] = 0x11; // flags: adv_type=1, has location
+        let mut data = vec![0u8; MIN_LEN];
+        data[FLAGS_OFFSET] = 1 | FLAG_HAS_LOCATION; // adv_type=1, has location
         data.extend_from_slice(&37774900i32.to_le_bytes());
         data.extend_from_slice(&(-122419400i32).to_le_bytes());
 
@@ -1478,12 +1490,12 @@ mod tests {
 
     #[test]
     fn test_parse_raw_advertisement_skips_unknown_feature_blocks() {
-        // flags: feature1 (0x20) + feature2 (0x40) + name (0x80), no
-        // location. Each feature block is 2 bytes we don't decode but must
-        // still skip correctly, otherwise the name would be read from the
-        // wrong offset (garbled, or misaligned into the feature bytes).
-        let mut data = vec![0u8; 101];
-        data[100] = 0x20 | 0x40 | 0x80;
+        // flags: feature1 + feature2 + name, no location. Each feature
+        // block is 2 bytes we don't decode but must still skip correctly,
+        // otherwise the name would be read from the wrong offset (garbled,
+        // or misaligned into the feature bytes).
+        let mut data = vec![0u8; MIN_LEN];
+        data[FLAGS_OFFSET] = FLAG_HAS_FEATURE1 | FLAG_HAS_FEATURE2 | FLAG_HAS_NAME;
         data.extend_from_slice(&[0xAA, 0xAA]); // feature1, skipped
         data.extend_from_slice(&[0xBB, 0xBB]); // feature2, skipped
         data.extend_from_slice(b"Node2");
@@ -1496,7 +1508,7 @@ mod tests {
 
     #[test]
     fn test_parse_raw_advertisement_too_short() {
-        let data = vec![0u8; 50];
+        let data = vec![0u8; MIN_LEN - 1];
         assert!(parse_raw_advertisement(&data).is_none());
     }
 
@@ -1506,8 +1518,8 @@ mod tests {
         // bytes — not enough for the 8-byte lat/lon. Must be rejected as a
         // parse failure rather than silently misreading the name from
         // inside the truncated location bytes.
-        let mut data = vec![0u8; 101];
-        data[100] = 0x90;
+        let mut data = vec![0u8; MIN_LEN];
+        data[FLAGS_OFFSET] = FLAG_HAS_LOCATION | FLAG_HAS_NAME;
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
 
         assert!(parse_raw_advertisement(&data).is_none());

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -604,6 +604,8 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
         return None;
     }
 
+    // Header byte layout: bits 0-1 = route type, bits 2-5 = payload type,
+    // bits 6-7 = payload format version.
     let header_byte = data[0];
     let route_type = RouteType::from(header_byte);
     let payload_type = PayloadType::from(header_byte >> 2);
@@ -654,39 +656,57 @@ pub fn parse_mesh_packet_header(data: &[u8]) -> Option<(MeshPacketHeader, &[u8])
 /// Parse a raw ADVERT payload (public key, timestamp, signature, flags and
 /// optional location/name), as carried by a [`PayloadType::Advert`] packet.
 pub fn parse_raw_advertisement(data: &[u8]) -> Option<RawAdvertisement> {
-    // public_key(32) + timestamp(4) + signature(64) + flags(1)
-    const MIN_LEN: usize = 32 + 4 + 64 + 1;
+    const PUBLIC_KEY_LEN: usize = 32;
+    const TIMESTAMP_LEN: usize = 4;
+    const SIGNATURE_LEN: usize = 64;
+    const FLAGS_LEN: usize = 1;
+
+    const TIMESTAMP_OFFSET: usize = PUBLIC_KEY_LEN;
+    const SIGNATURE_OFFSET: usize = TIMESTAMP_OFFSET + TIMESTAMP_LEN;
+    const FLAGS_OFFSET: usize = SIGNATURE_OFFSET + SIGNATURE_LEN;
+    const MIN_LEN: usize = FLAGS_OFFSET + FLAGS_LEN;
+
+    // Flag bits of the byte at FLAGS_OFFSET.
+    const FLAG_ADV_TYPE_MASK: u8 = 0x0F; // advertiser type (see Contact::contact_type)
+    const FLAG_HAS_LOCATION: u8 = 0x10; // 8 bytes: lat (i32 LE) + lon (i32 LE)
+    const FLAG_HAS_FEATURE1: u8 = 0x20; // 2 bytes, not currently decoded
+    const FLAG_HAS_FEATURE2: u8 = 0x40; // 2 bytes, not currently decoded
+    const FLAG_HAS_NAME: u8 = 0x80; // remaining bytes, UTF-8 name
+
+    const LOCATION_LEN: usize = 8;
+    const FEATURE_BLOCK_LEN: usize = 2;
+
     if data.len() < MIN_LEN {
         return None;
     }
 
     let public_key: [u8; 32] = read_bytes(data, 0).ok()?;
-    let timestamp = read_u32_le(data, 32).ok()?;
-    let signature: [u8; 64] = read_bytes(data, 36).ok()?;
-    let flags = data[100];
-    let adv_type = flags & 0x0F;
+    let timestamp = read_u32_le(data, TIMESTAMP_OFFSET).ok()?;
+    let signature: [u8; 64] = read_bytes(data, SIGNATURE_OFFSET).ok()?;
+    let flags = data[FLAGS_OFFSET];
+    let adv_type = flags & FLAG_ADV_TYPE_MASK;
 
     let mut offset = MIN_LEN;
 
-    let (lat, lon) = if flags & 0x10 != 0 {
+    let (lat, lon) = if flags & FLAG_HAS_LOCATION != 0 {
         // A declared location that does not fit means the capture is
         // truncated; every later offset would be wrong.
         let lat = read_i32_le(data, offset).ok()?;
         let lon = read_i32_le(data, offset + 4).ok()?;
-        offset += 8;
+        offset += LOCATION_LEN;
         (Some(lat), Some(lon))
     } else {
         (None, None)
     };
 
-    if flags & 0x20 != 0 {
-        offset += 2; // feature1, not currently decoded
+    if flags & FLAG_HAS_FEATURE1 != 0 {
+        offset += FEATURE_BLOCK_LEN;
     }
-    if flags & 0x40 != 0 {
-        offset += 2; // feature2, not currently decoded
+    if flags & FLAG_HAS_FEATURE2 != 0 {
+        offset += FEATURE_BLOCK_LEN;
     }
 
-    let name = if flags & 0x80 != 0 && data.len() > offset {
+    let name = if flags & FLAG_HAS_NAME != 0 && data.len() > offset {
         Some(read_string(data, offset, data.len() - offset))
     } else {
         None

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
 use crate::events::*;
-use crate::packets::{BinaryReqType, ControlType, PacketType};
+use crate::packets::{BinaryReqType, ControlType, PacketType, PayloadType};
 use crate::parsing::*;
 use crate::{Result, CHANNEL_INFO_LEN, CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
 
@@ -651,28 +651,84 @@ impl MessageReader {
             PacketType::PathDiscovery => {}
             PacketType::SetFloodScope => {}
             PacketType::SendControlData => {}
-            PacketType::RawData => {}
-            PacketType::LogData => {
-                // LOG_DATA format:
+            PacketType::RawData => {
+                // RAW_DATA push: reports a packet the node overheard "on
+                // air" (not necessarily addressed to or relayed by it).
                 // Byte 0: SNR (signed byte, divide by 4.0)
                 // Byte 1: RSSI (signed byte)
-                // Bytes 2+: Raw RF payload
+                // Byte 2: reserved
+                // Bytes 3+: the raw mesh packet, starting with its header byte
+                // See meshcore_py reader.py PacketType.RAW_DATA and
+                // meshcore_parser.py parsePacketPayload for the reference
+                // implementation this is ported from.
                 if payload.len() >= 2 {
                     let snr_byte = payload[0] as i8;
                     let snr = snr_byte as f32 / 4.0;
-
                     let rssi = payload[1] as i8 as i16;
 
-                    let rf_payload = if payload.len() > 2 {
-                        payload[2..].to_vec()
+                    let packet = if payload.len() > 3 {
+                        &payload[3..]
                     } else {
-                        Vec::new()
+                        &[] as &[u8]
                     };
+
+                    let (header, inner_payload) = match parse_mesh_packet_header(packet) {
+                        Some((header, remaining)) => (Some(header), remaining),
+                        None => (None, packet),
+                    };
+
+                    let advertisement = header
+                        .as_ref()
+                        .filter(|h| h.payload_type == PayloadType::Advert)
+                        .and_then(|_| parse_raw_advertisement(inner_payload));
+
+                    let raw_data = RawPacketData {
+                        snr,
+                        rssi,
+                        header,
+                        advertisement,
+                        payload: inner_payload.to_vec(),
+                    };
+
+                    let event =
+                        MeshCoreEvent::new(EventType::RawData, EventPayload::RawData(raw_data));
+                    self.dispatcher.emit(event).await;
+                }
+            }
+            PacketType::LogData => {
+                // LOG_DATA: pushed unconditionally for every packet the
+                // radio receives (Dispatcher::checkRecv() -> logRxRaw()),
+                // regardless of payload type or routing. Format:
+                // Byte 0: SNR (signed byte, divide by 4.0)
+                // Byte 1: RSSI (signed byte)
+                // Bytes 2+: the raw mesh packet, starting with its header byte
+                if payload.len() >= 2 {
+                    let snr_byte = payload[0] as i8;
+                    let snr = snr_byte as f32 / 4.0;
+                    let rssi = payload[1] as i8 as i16;
+
+                    let packet = if payload.len() > 2 {
+                        &payload[2..]
+                    } else {
+                        &[] as &[u8]
+                    };
+
+                    let (header, inner_payload) = match parse_mesh_packet_header(packet) {
+                        Some((header, remaining)) => (Some(header), remaining),
+                        None => (None, packet),
+                    };
+
+                    let advertisement = header
+                        .as_ref()
+                        .filter(|h| h.payload_type == PayloadType::Advert)
+                        .and_then(|_| parse_raw_advertisement(inner_payload));
 
                     let log_data = LogData {
                         snr,
                         rssi,
-                        payload: rf_payload,
+                        header,
+                        advertisement,
+                        payload: inner_payload.to_vec(),
                     };
                     let event =
                         MeshCoreEvent::new(EventType::LogData, EventPayload::LogData(log_data));
@@ -695,6 +751,7 @@ impl MessageReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::packets::RouteType;
     use std::time::Duration;
 
     fn create_reader() -> (MessageReader, Arc<EventDispatcher>) {
@@ -2316,6 +2373,229 @@ mod tests {
         match event.payload {
             EventPayload::Contacts(contacts) => assert_eq!(contacts.len(), 1),
             _ => panic!("Expected Contacts payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_raw_data_text_msg() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        let mut data = vec![PacketType::RawData as u8];
+        data.push(40); // snr_raw = 40, SNR = 10.0
+        data.push((-70i8) as u8); // rssi = -70
+        data.push(0xFF); // reserved
+
+        // Mesh packet: route=Flood(1), payload_type=TextMsg(2), payload_ver=0
+        data.push((2 << 2) | 1);
+        // path: hash_size=1, path_len=2
+        data.push(0b00_000010);
+        data.extend_from_slice(&[0xAA, 0xBB]); // path
+        data.extend_from_slice(&[0x01, 0x02, 0x03]); // opaque inner payload
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::RawData);
+        match event.payload {
+            EventPayload::RawData(raw) => {
+                assert_eq!(raw.snr, 10.0);
+                assert_eq!(raw.rssi, -70);
+                let header = raw.header.expect("expected a decoded header");
+                assert_eq!(header.route_type, RouteType::Flood);
+                assert_eq!(header.payload_type, PayloadType::TextMsg);
+                assert_eq!(header.path_len, 2);
+                assert_eq!(header.path, vec![0xAA, 0xBB]);
+                assert!(raw.advertisement.is_none());
+                assert_eq!(raw.payload, vec![0x01, 0x02, 0x03]);
+            }
+            _ => panic!("Expected RawData payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_raw_data_advert_decodes_advertiser() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        let mut data = vec![PacketType::RawData as u8];
+        data.push(20); // snr_raw = 20, SNR = 5.0
+        data.push((-90i8) as u8); // rssi = -90
+        data.push(0xFF); // reserved
+
+        // Mesh packet: route=Flood(1), payload_type=Advert(4), payload_ver=0
+        data.push((4 << 2) | 1);
+        data.push(0b00_000000); // no path hops
+
+        // ADVERT inner payload: pubkey(32) + timestamp(4) + signature(64) + flags(1)
+        data.extend_from_slice(&[0xAB; 32]); // pubkey
+        data.extend_from_slice(&999u32.to_le_bytes()); // timestamp
+        data.extend_from_slice(&[0xCD; 64]); // signature
+        data.push(0x80); // flags: has name only
+        data.extend_from_slice(b"Repeater1");
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::RawData);
+        match event.payload {
+            EventPayload::RawData(raw) => {
+                let header = raw.header.expect("expected a decoded header");
+                assert_eq!(header.payload_type, PayloadType::Advert);
+                let adv = raw.advertisement.expect("expected a decoded advertiser");
+                assert_eq!(adv.public_key, [0xAB; 32]);
+                assert_eq!(adv.timestamp, 999);
+                assert_eq!(adv.name.as_deref(), Some("Repeater1"));
+            }
+            _ => panic!("Expected RawData payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_raw_data_snr_rssi_only() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // Only SNR + RSSI, no reserved byte or packet bytes at all
+        let data = vec![PacketType::RawData as u8, 40, (-70i8) as u8];
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::RawData);
+        match event.payload {
+            EventPayload::RawData(raw) => {
+                assert_eq!(raw.snr, 10.0);
+                assert_eq!(raw.rssi, -70);
+                assert!(raw.header.is_none());
+                assert!(raw.payload.is_empty());
+            }
+            _ => panic!("Expected RawData payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_raw_data_too_short() {
+        let (reader, _dispatcher) = create_reader();
+
+        // Less than the 2 bytes required for SNR + RSSI: silently dropped,
+        // matching every other lenient push-notification handler above.
+        let result = reader.handle_rx(vec![PacketType::RawData as u8, 40]).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_log_data_decodes_header() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        let mut data = vec![PacketType::LogData as u8];
+        data.push(40); // snr_raw = 40, SNR = 10.0
+        data.push((-70i8) as u8); // rssi = -70
+                                  // no reserved byte here, unlike RAW_DATA
+
+        // Mesh packet: route=Direct(2), payload_type=Ack(3), payload_ver=0
+        data.push((3 << 2) | 2);
+        data.push(0b00_000000); // no path hops
+        data.extend_from_slice(&[0xEE, 0xFF]); // opaque inner payload
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::LogData);
+        match event.payload {
+            EventPayload::LogData(log) => {
+                assert_eq!(log.snr, 10.0);
+                assert_eq!(log.rssi, -70);
+                let header = log.header.expect("expected a decoded header");
+                assert_eq!(header.route_type, RouteType::Direct);
+                assert_eq!(header.payload_type, PayloadType::Ack);
+                assert!(log.advertisement.is_none());
+                assert_eq!(log.payload, vec![0xEE, 0xFF]);
+            }
+            _ => panic!("Expected LogData payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_log_data_advert_decodes_advertiser() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        let mut data = vec![PacketType::LogData as u8];
+        data.push(20); // snr_raw = 20, SNR = 5.0
+        data.push((-90i8) as u8); // rssi = -90
+
+        // Mesh packet: route=Flood(1), payload_type=Advert(4), payload_ver=0
+        data.push((4 << 2) | 1);
+        data.push(0b00_000000); // no path hops
+
+        data.extend_from_slice(&[0x11; 32]); // pubkey
+        data.extend_from_slice(&42u32.to_le_bytes()); // timestamp
+        data.extend_from_slice(&[0x22; 64]); // signature
+        data.push(0x80); // flags: has name only
+        data.extend_from_slice(b"Node2");
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::LogData);
+        match event.payload {
+            EventPayload::LogData(log) => {
+                let header = log.header.expect("expected a decoded header");
+                assert_eq!(header.payload_type, PayloadType::Advert);
+                let adv = log.advertisement.expect("expected a decoded advertiser");
+                assert_eq!(adv.public_key, [0x11; 32]);
+                assert_eq!(adv.name.as_deref(), Some("Node2"));
+            }
+            _ => panic!("Expected LogData payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_log_data_snr_rssi_only() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // Only SNR + RSSI, no packet bytes at all
+        let data = vec![PacketType::LogData as u8, 40, (-70i8) as u8];
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::LogData);
+        match event.payload {
+            EventPayload::LogData(log) => {
+                assert_eq!(log.snr, 10.0);
+                assert_eq!(log.rssi, -70);
+                assert!(log.header.is_none());
+                assert!(log.payload.is_empty());
+            }
+            _ => panic!("Expected LogData payload"),
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -652,8 +652,10 @@ impl MessageReader {
             PacketType::SetFloodScope => {}
             PacketType::SendControlData => {}
             PacketType::RawData => {
-                // RAW_DATA push: reports a packet the node overheard "on
-                // air" (not necessarily addressed to or relayed by it).
+                // RAW_DATA push: emitted only for directly-routed,
+                // not-yet-seen RAW_CUSTOM packets addressed to this node.
+                // See `RawPacketData` for the full semantics; use LOG_DATA
+                // to observe every received packet.
                 // Byte 0: SNR (signed byte, divide by 4.0)
                 // Byte 1: RSSI (signed byte)
                 // Byte 2: reserved

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,6 +38,13 @@ pub struct MessageReader {
     contacts_last_modification_timestamp: Arc<RwLock<u32>>,
 }
 
+/// Length of the SNR + RSSI prefix shared by RAW_DATA and LOG_DATA push
+/// payloads.
+const SNR_RSSI_LEN: usize = 2;
+/// RAW_DATA only: length of the reserved byte immediately after SNR/RSSI,
+/// before the opaque application payload.
+const RAW_DATA_RESERVED_LEN: usize = 1;
+
 /// Decodes a RAW_DATA push payload into a [`RawPacketData`]. Returns `None`
 /// if `payload` is too short to contain at least SNR + RSSI.
 ///
@@ -55,19 +62,14 @@ pub struct MessageReader {
 /// See meshcore_py reader.py PacketType.RAW_DATA for the reference
 /// implementation this is ported from.
 fn parse_raw_data(payload: &[u8]) -> Option<RawPacketData> {
-    if payload.len() < 2 {
-        return None;
-    }
-
-    let snr_byte = payload[0] as i8;
+    let snr_byte = *payload.first()? as i8;
     let snr = snr_byte as f32 / 4.0;
-    let rssi = payload[1] as i8 as i16;
+    let rssi = *payload.get(1)? as i8 as i16;
 
-    let inner_payload = if payload.len() > 3 {
-        payload[3..].to_vec()
-    } else {
-        Vec::new()
-    };
+    let inner_payload = payload
+        .get(SNR_RSSI_LEN + RAW_DATA_RESERVED_LEN..)
+        .map(<[u8]>::to_vec)
+        .unwrap_or_default();
 
     Some(RawPacketData {
         snr,
@@ -89,19 +91,11 @@ fn parse_raw_data(payload: &[u8]) -> Option<RawPacketData> {
 /// Byte 1: RSSI (signed byte)
 /// Bytes 2+: the raw mesh packet, starting with its header byte
 fn parse_log_data(payload: &[u8]) -> Option<LogData> {
-    if payload.len() < 2 {
-        return None;
-    }
-
-    let snr_byte = payload[0] as i8;
+    let snr_byte = *payload.first()? as i8;
     let snr = snr_byte as f32 / 4.0;
-    let rssi = payload[1] as i8 as i16;
+    let rssi = *payload.get(1)? as i8 as i16;
 
-    let packet = if payload.len() > 2 {
-        &payload[2..]
-    } else {
-        &[] as &[u8]
-    };
+    let packet = payload.get(SNR_RSSI_LEN..).unwrap_or(&[]);
 
     let (header, inner_payload) = match parse_mesh_packet_header(packet) {
         Some((header, remaining)) => (Some(header), remaining),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -38,6 +38,90 @@ pub struct MessageReader {
     contacts_last_modification_timestamp: Arc<RwLock<u32>>,
 }
 
+/// Decodes a RAW_DATA push payload into a [`RawPacketData`]. Returns `None`
+/// if `payload` is too short to contain at least SNR + RSSI.
+///
+/// RAW_DATA is emitted only for directly-routed, not-yet-seen RAW_CUSTOM
+/// packets addressed to this node. The firmware has already parsed and
+/// stripped the mesh header, transport code and path before delivering
+/// this — bytes 3+ are opaque application payload, not a mesh packet, so
+/// unlike LOG_DATA there is no header to decode.
+///
+/// Byte 0: SNR (signed byte, divide by 4.0)
+/// Byte 1: RSSI (signed byte)
+/// Byte 2: reserved
+/// Bytes 3+: opaque RAW_CUSTOM application payload
+///
+/// See meshcore_py reader.py PacketType.RAW_DATA for the reference
+/// implementation this is ported from.
+fn parse_raw_data(payload: &[u8]) -> Option<RawPacketData> {
+    if payload.len() < 2 {
+        return None;
+    }
+
+    let snr_byte = payload[0] as i8;
+    let snr = snr_byte as f32 / 4.0;
+    let rssi = payload[1] as i8 as i16;
+
+    let inner_payload = if payload.len() > 3 {
+        payload[3..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    Some(RawPacketData {
+        snr,
+        rssi,
+        payload: inner_payload,
+    })
+}
+
+/// Decodes a LOG_DATA push payload into a [`LogData`], best-effort decoding
+/// the mesh packet header and, for ADVERT payloads, the advertiser
+/// identity. Returns `None` if `payload` is too short to contain at least
+/// SNR + RSSI.
+///
+/// LOG_DATA is pushed unconditionally for every packet the radio receives
+/// (`Dispatcher::checkRecv()` -> `logRxRaw()`), regardless of payload type
+/// or routing.
+///
+/// Byte 0: SNR (signed byte, divide by 4.0)
+/// Byte 1: RSSI (signed byte)
+/// Bytes 2+: the raw mesh packet, starting with its header byte
+fn parse_log_data(payload: &[u8]) -> Option<LogData> {
+    if payload.len() < 2 {
+        return None;
+    }
+
+    let snr_byte = payload[0] as i8;
+    let snr = snr_byte as f32 / 4.0;
+    let rssi = payload[1] as i8 as i16;
+
+    let packet = if payload.len() > 2 {
+        &payload[2..]
+    } else {
+        &[] as &[u8]
+    };
+
+    let (header, inner_payload) = match parse_mesh_packet_header(packet) {
+        Some((header, remaining)) => (Some(header), remaining),
+        None => (None, packet),
+    };
+
+    let advertisement = header
+        .as_ref()
+        .filter(|h| h.payload_type == PayloadType::Advert)
+        .and_then(|_| parse_raw_advertisement(inner_payload));
+
+    Some(LogData {
+        snr,
+        rssi,
+        header,
+        advertisement,
+        payload: inner_payload.to_vec(),
+    })
+}
+
 impl MessageReader {
     /// Create a new message reader
     pub fn new(dispatcher: Arc<EventDispatcher>) -> Self {
@@ -652,75 +736,17 @@ impl MessageReader {
             PacketType::SetFloodScope => {}
             PacketType::SendControlData => {}
             PacketType::RawData => {
-                // RAW_DATA push: emitted only for directly-routed,
-                // not-yet-seen RAW_CUSTOM packets addressed to this node.
-                // The firmware has already parsed and stripped the mesh
-                // header, transport code and path before delivering this —
-                // bytes 3+ are opaque application payload, not a mesh
-                // packet, so unlike LOG_DATA there is no header to decode.
-                // Byte 0: SNR (signed byte, divide by 4.0)
-                // Byte 1: RSSI (signed byte)
-                // Byte 2: reserved
-                // Bytes 3+: opaque RAW_CUSTOM application payload
-                // See meshcore_py reader.py PacketType.RAW_DATA for the
-                // reference implementation this is ported from.
-                if payload.len() >= 2 {
-                    let snr_byte = payload[0] as i8;
-                    let snr = snr_byte as f32 / 4.0;
-                    let rssi = payload[1] as i8 as i16;
-
-                    let inner_payload = if payload.len() > 3 {
-                        payload[3..].to_vec()
-                    } else {
-                        Vec::new()
-                    };
-
-                    let raw_data = RawPacketData {
-                        snr,
-                        rssi,
-                        payload: inner_payload,
-                    };
-
+                // See `parse_raw_data` for the RAW_DATA wire format and why
+                // it carries no decodable header.
+                if let Some(raw_data) = parse_raw_data(payload) {
                     let event =
                         MeshCoreEvent::new(EventType::RawData, EventPayload::RawData(raw_data));
                     self.dispatcher.emit(event).await;
                 }
             }
             PacketType::LogData => {
-                // LOG_DATA: pushed unconditionally for every packet the
-                // radio receives (Dispatcher::checkRecv() -> logRxRaw()),
-                // regardless of payload type or routing. Format:
-                // Byte 0: SNR (signed byte, divide by 4.0)
-                // Byte 1: RSSI (signed byte)
-                // Bytes 2+: the raw mesh packet, starting with its header byte
-                if payload.len() >= 2 {
-                    let snr_byte = payload[0] as i8;
-                    let snr = snr_byte as f32 / 4.0;
-                    let rssi = payload[1] as i8 as i16;
-
-                    let packet = if payload.len() > 2 {
-                        &payload[2..]
-                    } else {
-                        &[] as &[u8]
-                    };
-
-                    let (header, inner_payload) = match parse_mesh_packet_header(packet) {
-                        Some((header, remaining)) => (Some(header), remaining),
-                        None => (None, packet),
-                    };
-
-                    let advertisement = header
-                        .as_ref()
-                        .filter(|h| h.payload_type == PayloadType::Advert)
-                        .and_then(|_| parse_raw_advertisement(inner_payload));
-
-                    let log_data = LogData {
-                        snr,
-                        rssi,
-                        header,
-                        advertisement,
-                        payload: inner_payload.to_vec(),
-                    };
+                // See `parse_log_data` for the LOG_DATA wire format.
+                if let Some(log_data) = parse_log_data(payload) {
                     let event =
                         MeshCoreEvent::new(EventType::LogData, EventPayload::LogData(log_data));
                     self.dispatcher.emit(event).await;
@@ -749,6 +775,41 @@ mod tests {
         let dispatcher = Arc::new(EventDispatcher::new());
         let reader = MessageReader::new(dispatcher.clone());
         (reader, dispatcher)
+    }
+
+    #[test]
+    fn test_parse_raw_data_too_short() {
+        assert!(parse_raw_data(&[]).is_none());
+        assert!(parse_raw_data(&[40]).is_none());
+    }
+
+    #[test]
+    fn test_parse_raw_data_decodes_opaque_payload() {
+        let payload = [40, (-70i8) as u8, 0xFF, 0x11, 0x22, 0x33];
+        let raw = parse_raw_data(&payload).expect("should decode");
+        assert_eq!(raw.snr, 10.0);
+        assert_eq!(raw.rssi, -70);
+        assert_eq!(raw.payload, vec![0x11, 0x22, 0x33]);
+    }
+
+    #[test]
+    fn test_parse_log_data_too_short() {
+        assert!(parse_log_data(&[]).is_none());
+        assert!(parse_log_data(&[40]).is_none());
+    }
+
+    #[test]
+    fn test_parse_log_data_decodes_header() {
+        // route=Flood, payload_type=Ack, payload_ver=0, no path hops
+        let header_byte = (3u8 << 2) | 1;
+        let payload = [40, (-70i8) as u8, header_byte, 0b00_000000, 0xEE, 0xFF];
+        let log = parse_log_data(&payload).expect("should decode");
+        assert_eq!(log.snr, 10.0);
+        assert_eq!(log.rssi, -70);
+        let header = log.header.expect("expected a decoded header");
+        assert_eq!(header.route_type, RouteType::Flood);
+        assert_eq!(header.payload_type, PayloadType::Ack);
+        assert_eq!(log.payload, vec![0xEE, 0xFF]);
     }
 
     #[tokio::test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -654,42 +654,31 @@ impl MessageReader {
             PacketType::RawData => {
                 // RAW_DATA push: emitted only for directly-routed,
                 // not-yet-seen RAW_CUSTOM packets addressed to this node.
-                // See `RawPacketData` for the full semantics; use LOG_DATA
-                // to observe every received packet.
+                // The firmware has already parsed and stripped the mesh
+                // header, transport code and path before delivering this —
+                // bytes 3+ are opaque application payload, not a mesh
+                // packet, so unlike LOG_DATA there is no header to decode.
                 // Byte 0: SNR (signed byte, divide by 4.0)
                 // Byte 1: RSSI (signed byte)
                 // Byte 2: reserved
-                // Bytes 3+: the raw mesh packet, starting with its header byte
-                // See meshcore_py reader.py PacketType.RAW_DATA and
-                // meshcore_parser.py parsePacketPayload for the reference
-                // implementation this is ported from.
+                // Bytes 3+: opaque RAW_CUSTOM application payload
+                // See meshcore_py reader.py PacketType.RAW_DATA for the
+                // reference implementation this is ported from.
                 if payload.len() >= 2 {
                     let snr_byte = payload[0] as i8;
                     let snr = snr_byte as f32 / 4.0;
                     let rssi = payload[1] as i8 as i16;
 
-                    let packet = if payload.len() > 3 {
-                        &payload[3..]
+                    let inner_payload = if payload.len() > 3 {
+                        payload[3..].to_vec()
                     } else {
-                        &[] as &[u8]
+                        Vec::new()
                     };
-
-                    let (header, inner_payload) = match parse_mesh_packet_header(packet) {
-                        Some((header, remaining)) => (Some(header), remaining),
-                        None => (None, packet),
-                    };
-
-                    let advertisement = header
-                        .as_ref()
-                        .filter(|h| h.payload_type == PayloadType::Advert)
-                        .and_then(|_| parse_raw_advertisement(inner_payload));
 
                     let raw_data = RawPacketData {
                         snr,
                         rssi,
-                        header,
-                        advertisement,
-                        payload: inner_payload.to_vec(),
+                        payload: inner_payload,
                     };
 
                     let event =
@@ -2379,7 +2368,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_rx_raw_data_text_msg() {
+    async fn test_handle_rx_raw_data_carries_opaque_payload() {
+        // RAW_DATA's payload (bytes 3+) is already-stripped RAW_CUSTOM
+        // application data, not a mesh packet — even bytes that would
+        // decode as a plausible-looking header/path must be passed through
+        // verbatim, with no attempt to parse them.
         let (reader, dispatcher) = create_reader();
         let mut receiver = dispatcher.receiver();
 
@@ -2387,13 +2380,7 @@ mod tests {
         data.push(40); // snr_raw = 40, SNR = 10.0
         data.push((-70i8) as u8); // rssi = -70
         data.push(0xFF); // reserved
-
-        // Mesh packet: route=Flood(1), payload_type=TextMsg(2), payload_ver=0
-        data.push((2 << 2) | 1);
-        // path: hash_size=1, path_len=2
-        data.push(0b00_000010);
-        data.extend_from_slice(&[0xAA, 0xBB]); // path
-        data.extend_from_slice(&[0x01, 0x02, 0x03]); // opaque inner payload
+        data.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55]); // opaque application payload
 
         reader.handle_rx(data).await.unwrap();
 
@@ -2407,55 +2394,7 @@ mod tests {
             EventPayload::RawData(raw) => {
                 assert_eq!(raw.snr, 10.0);
                 assert_eq!(raw.rssi, -70);
-                let header = raw.header.expect("expected a decoded header");
-                assert_eq!(header.route_type, RouteType::Flood);
-                assert_eq!(header.payload_type, PayloadType::TextMsg);
-                assert_eq!(header.path_len, 2);
-                assert_eq!(header.path, vec![0xAA, 0xBB]);
-                assert!(raw.advertisement.is_none());
-                assert_eq!(raw.payload, vec![0x01, 0x02, 0x03]);
-            }
-            _ => panic!("Expected RawData payload"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_handle_rx_raw_data_advert_decodes_advertiser() {
-        let (reader, dispatcher) = create_reader();
-        let mut receiver = dispatcher.receiver();
-
-        let mut data = vec![PacketType::RawData as u8];
-        data.push(20); // snr_raw = 20, SNR = 5.0
-        data.push((-90i8) as u8); // rssi = -90
-        data.push(0xFF); // reserved
-
-        // Mesh packet: route=Flood(1), payload_type=Advert(4), payload_ver=0
-        data.push((4 << 2) | 1);
-        data.push(0b00_000000); // no path hops
-
-        // ADVERT inner payload: pubkey(32) + timestamp(4) + signature(64) + flags(1)
-        data.extend_from_slice(&[0xAB; 32]); // pubkey
-        data.extend_from_slice(&999u32.to_le_bytes()); // timestamp
-        data.extend_from_slice(&[0xCD; 64]); // signature
-        data.push(0x80); // flags: has name only
-        data.extend_from_slice(b"Repeater1");
-
-        reader.handle_rx(data).await.unwrap();
-
-        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(event.event_type, EventType::RawData);
-        match event.payload {
-            EventPayload::RawData(raw) => {
-                let header = raw.header.expect("expected a decoded header");
-                assert_eq!(header.payload_type, PayloadType::Advert);
-                let adv = raw.advertisement.expect("expected a decoded advertiser");
-                assert_eq!(adv.public_key, [0xAB; 32]);
-                assert_eq!(adv.timestamp, 999);
-                assert_eq!(adv.name.as_deref(), Some("Repeater1"));
+                assert_eq!(raw.payload, vec![0x11, 0x22, 0x33, 0x44, 0x55]);
             }
             _ => panic!("Expected RawData payload"),
         }
@@ -2481,7 +2420,6 @@ mod tests {
             EventPayload::RawData(raw) => {
                 assert_eq!(raw.snr, 10.0);
                 assert_eq!(raw.rssi, -70);
-                assert!(raw.header.is_none());
                 assert!(raw.payload.is_empty());
             }
             _ => panic!("Expected RawData payload"),


### PR DESCRIPTION
## Summary

`PacketType::RawData` (0x84) was previously received and silently dropped (`PacketType::RawData => {}`). This PR:

- Adds `RouteType`/`PayloadType` enums (`packets.rs`) decoding the 1-byte mesh packet header (route type, payload type, payload version), matching the existing `BinaryReqType`/`ControlType`/`AnonReqType` style.
- Adds `MeshPacketHeader` and `RawAdvertisement` (`events.rs`), used to decode **both** `RawData` (`RawPacketData`) and `LogData`: SNR/RSSI, the header, the transport code (if present), the hop path, and — best-effort — the advertiser's identity when `payload_type` is `Advert`. Other payload types (direct/channel messages) stay as opaque bytes in `payload`, since decoding them needs per-channel secrets this reader has no access to.
- Adds `parse_mesh_packet_header()` and `parse_raw_advertisement()` to `parsing.rs`.
- Adds `examples/rf_packet_monitor.rs` demonstrating a live monitor over serial.
- Trims the `tokio` dependency from `features = ["full", ...]` down to `["sync", "time", "macros", "rt"]`, with `io-util`/`net` only pulled in by the transports that need them (`serial`/`tcp`), plus `rt-multi-thread`/`signal` moved to `[dev-dependencies]` (examples/doctests only). Downstream consumers currently get tokio's full feature set unconditionally via feature unification; this removes that.

## Important: RAW_DATA vs LOG_DATA

I initially assumed `RawData` was a general "hear every packet" monitor. Verifying against the firmware itself (`meshcore-dev/MeshCore`, `Dispatcher.cpp` / `examples/companion_radio/MyMesh.cpp`) showed that's wrong:

- **`LOG_DATA`** (`PUSH_CODE_LOG_RX_DATA`) is pushed unconditionally by `Dispatcher::checkRecv()` for *every* packet the radio receives, regardless of payload type or routing — no activation needed. This is the general RF monitor, and what `examples/rf_packet_monitor.rs` subscribes to.
- **`RAW_DATA`** is much narrower: `onRawDataRecv()` only fires for directly-routed, not-yet-seen `PAYLOAD_TYPE_RAW_CUSTOM` packets (sent by another app via the companion `SEND_RAW_DATA` command). Regular mesh traffic never triggers it. `RawPacketData`'s doc comment calls this out explicitly to avoid the same mix-up for future readers.

The wire format (SNR/RSSI[/reserved for RAW_DATA], then header+path+payload) and the packet header bit layout (route_type: bits 0-1, payload_type: bits 2-5, payload_version: bits 6-7, then optional 4-byte transport code, then a path-length/hash-size byte and path) were verified against the reference implementation in `meshcore_py` (`reader.py` `PacketType.RAW_DATA`/`LOG_DATA` and `meshcore_parser.py` `parsePacketPayload`), which this crate is already a port of.

## Test plan

- [x] 44 new unit tests covering the new enums, the two new parsing functions, and the reader wiring for both `RAW_DATA` and `LOG_DATA` (including short-payload edge cases) — 268 tests total, all passing
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --tests --no-deps --all-features --all-targets`
- [x] `cargo build --release` and `cargo publish --dry-run --allow-dirty --no-verify`
- [x] `cargo check --no-default-features` and each of `--features {serial,tcp,ble}` individually, to validate the tokio feature trim
- [x] `cargo tree -e features -i tokio` confirms `fs`/`io-std`/`process`/`parking_lot`/`test-util` are no longer pulled in
- [x] `examples/rf_packet_monitor.rs` run live against a real MeshCore node (BLE and serial), confirmed `LogData` events with decoded header/path/advertiser arrive as expected

Opened as a draft since this bundles two logically-separate changes (the RAW_DATA/LOG_DATA decoding, and the tokio feature trim) — happy to split into two PRs if preferred.