### PR TITLE
Trim tokio features from "full" to what's actually used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,7 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -543,16 +543,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,7 +819,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["meshcore", "lora", "mesh", "radio"]
 categories = ["network-programming", "embedded", "hardware-support"]
 
 [dependencies]
-tokio = { version = "1", features = ["full", "sync", "time", "io-util"] }
+tokio = { version = "1", default-features = false, features = ["sync", "time", "macros", "rt"] }
 tokio-serial = { version = "5", optional = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 thiserror = "2"
@@ -23,12 +23,13 @@ uuid = { version = "1" }
 
 [features]
 default = ["serial", "tcp", "ble"]
-serial = ["dep:tokio-serial"]
-tcp = []
+serial = ["dep:tokio-serial", "tokio/io-util"]
+tcp = ["tokio/net", "tokio/io-util"]
 ble = ["btleplug"]
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
 
 # Declared explicitly so `required-features` can be set; without it Cargo
 # auto-discovers this example and tries to build it even when `serial` is off,


### PR DESCRIPTION
## Summary

Split out from #59 per review feedback (this is an unrelated dependency change bundled with the RAW_DATA/LOG_DATA decoding work — separating it for git log cleanliness).

`tokio` was requested with `features = ["full", ...]`, which forces every downstream consumer of this crate to build tokio's entire feature set (`fs`, `io-std`, `process`, `parking_lot`, `test-util`, ...) via Cargo feature unification, regardless of what they actually need.

- `[dependencies]`: `default-features = false, features = ["sync", "time", "macros", "rt"]` — the baseline needed unconditionally by the core dispatcher/reader/command handler (sync primitives, the `select!` macro and timeouts in `wait_for_event`/`wait_for_any_event`, and `rt` for the `JoinHandle` type + `tokio::spawn` used to drive transports).
- `[features]`: `io-util` and `net` are now only pulled in by the transports that actually need them (`serial`/`tcp`), instead of being part of the unconditional baseline.
- `[dev-dependencies]`: add `rt-multi-thread` + `signal`, needed only to build/run the examples and doctests (`#[tokio::main]`, `tokio::signal::ctrl_c()`). Dev-dependency features never propagate to downstream consumers, so this doesn't affect the trim above.

## Test plan

- [x] `cargo tree -e features -i tokio` confirms `fs`/`io-std`/`process`/`parking_lot`/`test-util` are no longer pulled in by default
- [x] `cargo check --no-default-features` and each of `--features {serial,tcp,ble}` individually, to validate the trim per transport
- [x] Full test suite (247 tests + 2 doctests), `cargo fmt --all -- --check`, `cargo clippy --tests --no-deps --all-features --all-targets` — all clean
- [x] `cargo build --all-features` (release-equivalent) still passes