### PR TITLE
Fix remove_contact/export_contact sending a 6-byte prefix instead of the full public key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ required-features = ["serial"]
 
 [[example]]
 name = "rf_packet_monitor"
+
+[[example]]
+name = "add_remove_contact"

--- a/examples/add_remove_contact.rs
+++ b/examples/add_remove_contact.rs
@@ -1,0 +1,106 @@
+//! Example: add a contact, verify it's there, then remove it again.
+//!
+//! Exercises `CommandHandler::add_contact` and `CommandHandler::remove_contact`
+//! end-to-end against a real node — a regression check for `remove_contact`'s
+//! wire format: it must send the contact's full 32-byte public key, not just
+//! a 6-byte prefix, or the node never responds (see CHANGELOG/git history).
+//!
+//! The contact added is obviously synthetic (public key bytes 0x00..0x1F,
+//! name "meshcore-rs-example-test") so it's never mistaken for a real
+//! contact, and easy to spot/remove by hand should the example be
+//! interrupted before it cleans up after itself.
+//!
+//! Usage: exactly one of the following is required
+//!   cargo run --example add_remove_contact --features serial -- --serial <port>
+//!   cargo run --example add_remove_contact --features tcp -- --tcp <host:port>
+//!   cargo run --example add_remove_contact --features ble -- --ble <device-name>
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{connect, parse_args, ConnectionArgs};
+use meshcore_rs::events::Contact;
+
+/// Public key for the synthetic test contact: sequential bytes 0x00..0x1F,
+/// so it's unmistakably not a real device's key.
+const TEST_PUBLIC_KEY: [u8; 32] = {
+    let mut key = [0u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        key[i] = i as u8;
+        i += 1;
+    }
+    key
+};
+const TEST_CONTACT_NAME: &str = "meshcore-rs-example-test";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = match parse_args(std::env::args().skip(1)) {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(1);
+        }
+    };
+
+    run(args).await
+}
+
+async fn run(args: ConnectionArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let meshcore = connect(&args).await?;
+
+    let self_info = meshcore.commands().lock().await.send_appstart().await?;
+    println!("Connected to device: {}", self_info.name);
+
+    let contact = Contact {
+        public_key: TEST_PUBLIC_KEY,
+        contact_type: 1, // CLI/Chat, per the firmware's CONTACT_TYPENAMES
+        flags: 0,
+        path_len: -1, // unknown route: flood
+        out_path: Vec::new(),
+        adv_name: TEST_CONTACT_NAME.to_string(),
+        last_advert: 0,
+        adv_lat: 0,
+        adv_lon: 0,
+        last_modification_timestamp: 0,
+    };
+
+    println!("\nAdding test contact {TEST_CONTACT_NAME:?}...");
+    meshcore
+        .commands()
+        .lock()
+        .await
+        .add_contact(&contact)
+        .await?;
+    println!("  -> add_contact returned Ok.");
+
+    let after_add = meshcore.commands().lock().await.get_contacts(0).await?;
+    let found = after_add.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
+    println!("  Present in the node's contact list: {found}");
+
+    println!("\nRemoving test contact {TEST_CONTACT_NAME:?}...");
+    meshcore
+        .commands()
+        .lock()
+        .await
+        .remove_contact(&contact)
+        .await?;
+    println!("  -> remove_contact returned Ok.");
+
+    let after_remove = meshcore.commands().lock().await.get_contacts(0).await?;
+    let still_present = after_remove.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
+    println!("  Still present in the node's contact list: {still_present}");
+    if still_present {
+        eprintln!(
+            "WARNING: test contact was not actually removed -- you may need to remove it by hand."
+        );
+    }
+
+    meshcore.disconnect().await?;
+    Ok(())
+}

--- a/examples/add_remove_contact.rs
+++ b/examples/add_remove_contact.rs
@@ -79,26 +79,47 @@ async fn run(args: ConnectionArgs) -> Result<(), Box<dyn std::error::Error>> {
         .await?;
     println!("  -> add_contact returned Ok.");
 
-    let after_add = meshcore.commands().lock().await.get_contacts(0).await?;
-    let found = after_add.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
-    println!("  Present in the node's contact list: {found}");
+    // From here on the contact may exist on the device -- always attempt
+    // removal and disconnect below, even if a verification step fails,
+    // instead of bailing out via `?` and leaving it stranded.
+    match meshcore.commands().lock().await.get_contacts(0).await {
+        Ok(after_add) => {
+            let found = after_add.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
+            println!("  Present in the node's contact list: {found}");
+        }
+        Err(err) => eprintln!("  WARNING: failed to verify the contact was added: {err}"),
+    }
 
     println!("\nRemoving test contact {TEST_CONTACT_NAME:?}...");
-    meshcore
+    match meshcore
         .commands()
         .lock()
         .await
         .remove_contact(&contact)
-        .await?;
-    println!("  -> remove_contact returned Ok.");
+        .await
+    {
+        Ok(()) => {
+            println!("  -> remove_contact returned Ok.");
 
-    let after_remove = meshcore.commands().lock().await.get_contacts(0).await?;
-    let still_present = after_remove.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
-    println!("  Still present in the node's contact list: {still_present}");
-    if still_present {
-        eprintln!(
-            "WARNING: test contact was not actually removed -- you may need to remove it by hand."
-        );
+            match meshcore.commands().lock().await.get_contacts(0).await {
+                Ok(after_remove) => {
+                    let still_present =
+                        after_remove.iter().any(|c| c.public_key == TEST_PUBLIC_KEY);
+                    println!("  Still present in the node's contact list: {still_present}");
+                    if still_present {
+                        eprintln!(
+                            "WARNING: test contact was not actually removed -- you may need to remove it by hand."
+                        );
+                    }
+                }
+                Err(err) => {
+                    eprintln!("  WARNING: failed to verify the contact was removed: {err}")
+                }
+            }
+        }
+        Err(err) => eprintln!(
+            "  WARNING: remove_contact failed: {err} -- you may need to remove it by hand."
+        ),
     }
 
     meshcore.disconnect().await?;

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -581,10 +581,12 @@ impl CommandHandler {
     /// Format: [CMD_REMOVE_CONTACT=0x0F][pubkey: 32]
     pub async fn remove_contact(&self, key: impl Into<Destination>) -> Result<()> {
         let dest: Destination = key.into();
-        let prefix = dest.prefix()?;
+        let pubkey = dest.public_key().ok_or_else(|| {
+            Error::invalid_param("Remove contact requires full 32-byte public key")
+        })?;
 
         let mut data = vec![CMD_REMOVE_CONTACT];
-        data.extend_from_slice(&prefix);
+        data.extend_from_slice(&pubkey);
         self.send(&data, Some(EventType::Ok)).await?;
         Ok(())
     }
@@ -595,9 +597,11 @@ impl CommandHandler {
     pub async fn export_contact(&self, key: Option<impl Into<Destination>>) -> Result<String> {
         let data = if let Some(k) = key {
             let dest: Destination = k.into();
-            let prefix = dest.prefix()?;
+            let pubkey = dest.public_key().ok_or_else(|| {
+                Error::invalid_param("Export contact requires full 32-byte public key")
+            })?;
             let mut d = vec![CMD_EXPORT_CONTACT];
-            d.extend_from_slice(&prefix);
+            d.extend_from_slice(&pubkey);
             d
         } else {
             vec![CMD_EXPORT_CONTACT]
@@ -1715,6 +1719,72 @@ mod tests {
         let result: Result<String> = handler.export_contact(None::<&str>).await;
         assert!(result.is_ok());
         assert!(result.unwrap().starts_with("mod.rs://"));
+    }
+
+    #[tokio::test]
+    async fn test_export_contact_with_key_sends_full_public_key() {
+        // Regression test: this used to send only a 6-byte prefix, despite
+        // the documented wire format requiring the full 32-byte public key.
+        let (handler, mut rx, dispatcher) = create_test_handler();
+        let pubkey_hex = "bb".repeat(32);
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent[0], CMD_EXPORT_CONTACT);
+            assert_eq!(sent.len(), 1 + 32);
+            assert_eq!(&sent[1..], [0xbbu8; 32].as_slice());
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::ContactUri,
+                    EventPayload::String("mc://...".to_string()),
+                ))
+                .await;
+        });
+
+        let result: Result<String> = handler.export_contact(Some(pubkey_hex.as_str())).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_export_contact_with_prefix_only_errors() {
+        let (handler, _rx, _dispatcher) = create_test_handler();
+        // Only a 6-byte prefix (12 hex chars) -- not enough for the
+        // required 32-byte public key.
+        let result: Result<String> = handler.export_contact(Some("aabbccddeeff")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_remove_contact_sends_full_public_key() {
+        // Regression test: this used to send only a 6-byte prefix, despite
+        // the documented wire format requiring the full 32-byte public key
+        // -- causing the real firmware to never respond (timeout).
+        let (handler, mut rx, dispatcher) = create_test_handler();
+        let pubkey_hex = "aa".repeat(32);
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent[0], CMD_REMOVE_CONTACT);
+            assert_eq!(sent.len(), 1 + 32);
+            assert_eq!(&sent[1..], [0xaau8; 32].as_slice());
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::Ok, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.remove_contact(pubkey_hex.as_str()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_remove_contact_with_prefix_only_errors() {
+        let (handler, _rx, _dispatcher) = create_test_handler();
+        let result = handler.remove_contact("aabbccddeeff").await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Deleting a contact from a downstream app (over BLE, against a real companion node) failed with
`MeshCore error: Timeout waiting for Some(Ok)`, and the BLE connection then dropped and
reconnected. `remove_contact` never got an `Ok` response from the node.

## Root cause

`remove_contact` and `export_contact` (`src/commands/base.rs`) build their command frame from
`dest.prefix()` — 6 bytes — instead of `dest.public_key()` — the full 32 bytes. Sending a
6-byte frame where the companion firmware expects 32 explains the symptom: the node never
recognizes/acknowledges the (malformed, too-short) command.

## Sources on the required key size

- **The functions' own doc comments** already declare the wire format:
  `Format: [CMD_REMOVE_CONTACT=0x0F][pubkey: 32]` and
  `Format: [CMD_EXPORT_CONTACT=0x11][pubkey: 32 optional]` — 32 bytes, not 6.
- **Sibling functions with the identical requirement are implemented correctly** and were used
  as the reference for this fix: `send_login` (`[pubkey: 32]`), `send_logout` (`[pubkey: 32]`),
  `send_binary_req` (`[pubkey: 32]`) — all three call `dest.public_key()` and return a clean
  `Error::invalid_param(...)` if only a prefix is available. `remove_contact`/`export_contact`
  were the only two call sites still using `.prefix()`.
- **Git history confirms this was never correct, not a regression**: `git log -p -L` on
  `remove_contact` shows the `[pubkey: 32]` doc comment was added in the "Apply patch from
  ViezeVingertjes" commit (documenting the real protocol), but the implementation was *not*
  updated to match at the same time — and has sent only a prefix since the crate's very first
  commit. No test ever exercised either function with an actual key, so it went unnoticed.

## Fix

- `remove_contact`/`export_contact` now use `dest.public_key()`, erroring cleanly
  (`Error::invalid_param`) if only a prefix is available — matching `send_login`/`send_logout`/
  `send_binary_req`.
- Added regression tests for both functions: correct 32-byte wire bytes on success, and a clean
  error when only a 6-byte prefix is supplied.
- Added `examples/add_remove_contact.rs` (using the shared `common` connection-args module) as
  an end-to-end demo/regression check: adds an obviously-synthetic test contact (public key
  `0x00..0x1F`, name `meshcore-rs-example-test`), confirms it's present, removes it, confirms
  it's gone.

## Verification

- `cargo test`: 277 passed, incl. 4 new tests for this change.
- `cargo clippy --tests --no-deps --all-features --all-targets`: clean.
- `cargo fmt --all -- --check`: clean.
- `jonesy`: no new panic points introduced (17 pre-existing, all in `parsing.rs`/`reader.rs`,
  none in the touched code).
- `cargo llvm-cov`: every added/changed line in `remove_contact`/`export_contact` is covered by
  the new tests.
- **Verified against a real node** (BLE, `MeshCore-F4FEZ_Tracker_2`) via
  `examples/add_remove_contact.rs`: add + remove both succeeded, no timeout, no BLE disconnect —
  confirming the fix resolves the originally reported issue.

## Status

Opening as **draft**: this branch is based on top of #59
(https://github.com/andrewdavidmackenzie/meshcore-rs/pull/59, still open), so it carries that
PR's changes until it lands. Marking ready for review once #59 is merged and this branch is
rebased.