### PR TITLE
Exclude examples from test coverage measurement

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Clean up coverage
         if: runner.os != 'Windows'
         run: |
-          grcov . --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "**/test_helper.rs" --ignore "**/icons.rs" --ignore "**/styles.rs" -o lcov.info
+          grcov . --binary-path target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "**/test_helper.rs" --ignore "**/icons.rs" --ignore "**/styles.rs" --ignore "**/examples/**" -o lcov.info
           lcov --remove lcov.info 'target/debug/build/**' 'target/release/build/**' '/usr*' '**/errors.rs' \
-          '**/build.rs' '*tests/*' '**/test_helper.rs' '**/icons.rs' '**/styles.rs' --ignore-errors unused,unused --ignore-errors unsupported --ignore-errors \
+          '**/build.rs' '*tests/*' '**/test_helper.rs' '**/icons.rs' '**/styles.rs' '**/examples/**' --ignore-errors unused,unused --ignore-errors unsupported --ignore-errors \
           inconsistent --ignore-errors empty,empty -o lcov.info --erase-functions "(?=^.*fmt).+" --erase-functions "(?=^.*tests::).+"
 
       - name: UploadCoverage


### PR DESCRIPTION
Remove `examples/**` from coverage by adding `--ignore` to grcov and `lcov --remove` patterns in the CI workflow.

Fixes #65