### PR TITLE
Factor out AdvertResponse parsing into standalone function

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -2,8 +2,8 @@
 
 use crate::error::Error;
 use crate::events::{
-    AclEntry, ChannelMessage, Contact, ContactMessage, DeviceInfoData, MeshPacketHeader, MmaEntry,
-    Neighbour, NeighboursData, RawAdvertisement, SelfInfo, StatusData,
+    AclEntry, AdvertResponseData, ChannelMessage, Contact, ContactMessage, DeviceInfoData,
+    MeshPacketHeader, MmaEntry, Neighbour, NeighboursData, RawAdvertisement, SelfInfo, StatusData,
 };
 use crate::packets::{PayloadType, RouteType};
 use crate::Result;
@@ -782,6 +782,102 @@ pub fn hex_decode(s: &str) -> Result<Vec<u8>> {
 /// Encode bytes as a hex string
 pub fn hex_encode(data: &[u8]) -> String {
     data.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+// --- AdvertResponse wire-format layout ---
+//
+// Byte offsets and sizes for the PacketType::AdvertResponse payload,
+// returned by the device in reply to an advert request.
+
+/// Length of the request tag echoed back in the response.
+const ADVERT_RESP_TAG_LEN: usize = 4;
+/// Length of the 32-byte public key of the advertiser.
+const ADVERT_RESP_PUBKEY_LEN: usize = 32;
+/// Length of the advertisement type field.
+const ADVERT_RESP_ADV_TYPE_LEN: usize = 1;
+/// Fixed width of the node name field (padded / null-terminated).
+const ADVERT_RESP_NODE_NAME_LEN: usize = 32;
+/// Length of the timestamp field (u32 LE).
+const ADVERT_RESP_TIMESTAMP_LEN: usize = 4;
+/// Length of the flags field.
+const ADVERT_RESP_FLAGS_LEN: usize = 1;
+
+const ADVERT_RESP_TAG_OFFSET: usize = 0;
+const ADVERT_RESP_PUBKEY_OFFSET: usize = ADVERT_RESP_TAG_OFFSET + ADVERT_RESP_TAG_LEN;
+const ADVERT_RESP_ADV_TYPE_OFFSET: usize = ADVERT_RESP_PUBKEY_OFFSET + ADVERT_RESP_PUBKEY_LEN;
+const ADVERT_RESP_NODE_NAME_OFFSET: usize = ADVERT_RESP_ADV_TYPE_OFFSET + ADVERT_RESP_ADV_TYPE_LEN;
+const ADVERT_RESP_TIMESTAMP_OFFSET: usize =
+    ADVERT_RESP_NODE_NAME_OFFSET + ADVERT_RESP_NODE_NAME_LEN;
+const ADVERT_RESP_FLAGS_OFFSET: usize = ADVERT_RESP_TIMESTAMP_OFFSET + ADVERT_RESP_TIMESTAMP_LEN;
+
+/// Minimum payload length: tag + pubkey + adv_type + name + timestamp + flags.
+const ADVERT_RESP_MIN_LEN: usize = ADVERT_RESP_FLAGS_OFFSET + ADVERT_RESP_FLAGS_LEN;
+
+/// Offset of the optional latitude field (i32 LE), present when the
+/// payload extends beyond the flags byte.
+const ADVERT_RESP_LAT_OFFSET: usize = ADVERT_RESP_MIN_LEN;
+/// Length of one coordinate field (i32 LE).
+const ADVERT_RESP_COORD_LEN: usize = 4;
+/// Offset of the optional longitude field (i32 LE).
+const ADVERT_RESP_LON_OFFSET: usize = ADVERT_RESP_LAT_OFFSET + ADVERT_RESP_COORD_LEN;
+/// Minimum payload length to include both lat and lon.
+const ADVERT_RESP_LATLON_MIN_LEN: usize = ADVERT_RESP_LON_OFFSET + ADVERT_RESP_COORD_LEN;
+/// Offset of the optional node description field, present when the
+/// payload extends beyond lat/lon.
+const ADVERT_RESP_NODE_DESC_OFFSET: usize = ADVERT_RESP_LATLON_MIN_LEN;
+/// Fixed width of the optional node description field.
+const ADVERT_RESP_NODE_DESC_LEN: usize = 32;
+
+/// Parse an [`AdvertResponseData`] from a raw `PacketType::AdvertResponse`
+/// payload.
+///
+/// Returns `None` if the payload is too short to contain the mandatory
+/// fields (tag + pubkey + adv_type + node_name + timestamp + flags = 74
+/// bytes).
+pub fn parse_advert_response(payload: &[u8]) -> Option<AdvertResponseData> {
+    if payload.len() < ADVERT_RESP_MIN_LEN {
+        return None;
+    }
+
+    let tag: [u8; 4] = read_bytes(payload, ADVERT_RESP_TAG_OFFSET).ok()?;
+    let pubkey: [u8; 32] = read_bytes(payload, ADVERT_RESP_PUBKEY_OFFSET).ok()?;
+    let adv_type = *payload.get(ADVERT_RESP_ADV_TYPE_OFFSET)?;
+    let node_name = read_string(
+        payload,
+        ADVERT_RESP_NODE_NAME_OFFSET,
+        ADVERT_RESP_NODE_NAME_LEN,
+    );
+    let timestamp = read_u32_le(payload, ADVERT_RESP_TIMESTAMP_OFFSET).unwrap_or(0);
+    let flags = *payload.get(ADVERT_RESP_FLAGS_OFFSET).unwrap_or(&0);
+
+    let (lat, lon, node_desc) = if payload.len() >= ADVERT_RESP_LATLON_MIN_LEN {
+        let lat = Some(read_i32_le(payload, ADVERT_RESP_LAT_OFFSET).unwrap_or(0));
+        let lon = Some(read_i32_le(payload, ADVERT_RESP_LON_OFFSET).unwrap_or(0));
+        let desc = if payload.len() > ADVERT_RESP_NODE_DESC_OFFSET {
+            Some(read_string(
+                payload,
+                ADVERT_RESP_NODE_DESC_OFFSET,
+                ADVERT_RESP_NODE_DESC_LEN,
+            ))
+        } else {
+            None
+        };
+        (lat, lon, desc)
+    } else {
+        (None, None, None)
+    };
+
+    Some(AdvertResponseData {
+        tag,
+        pubkey,
+        adv_type,
+        node_name,
+        timestamp,
+        flags,
+        lat,
+        lon,
+        node_desc,
+    })
 }
 
 #[cfg(test)]
@@ -1569,5 +1665,119 @@ mod tests {
         data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]);
 
         assert!(parse_raw_advertisement(&data).is_none());
+    }
+
+    // ========== parse_advert_response tests ==========
+
+    /// Build a minimal valid AdvertResponse payload (74 bytes: tag + pubkey
+    /// + adv_type + node_name + timestamp + flags).
+    fn build_advert_response_payload() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // tag
+        data.extend_from_slice(&[0xAA; 32]); // pubkey
+        data.push(2); // adv_type
+        let mut name = [0u8; 32];
+        name[..5].copy_from_slice(b"TestN");
+        data.extend_from_slice(&name); // node_name (32 bytes)
+        data.extend_from_slice(&1700000000u32.to_le_bytes()); // timestamp
+        data.push(0x05); // flags
+        data
+    }
+
+    #[test]
+    fn test_parse_advert_response_too_short() {
+        let data = vec![0u8; ADVERT_RESP_MIN_LEN - 1];
+        assert!(parse_advert_response(&data).is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_empty() {
+        assert!(parse_advert_response(&[]).is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_minimal() {
+        let data = build_advert_response_payload();
+        assert_eq!(data.len(), ADVERT_RESP_MIN_LEN);
+
+        let resp = parse_advert_response(&data).unwrap();
+        assert_eq!(resp.tag, [0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(resp.pubkey, [0xAA; 32]);
+        assert_eq!(resp.adv_type, 2);
+        assert_eq!(resp.node_name, "TestN");
+        assert_eq!(resp.timestamp, 1700000000);
+        assert_eq!(resp.flags, 0x05);
+        assert!(resp.lat.is_none());
+        assert!(resp.lon.is_none());
+        assert!(resp.node_desc.is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_with_latlon() {
+        let mut data = build_advert_response_payload();
+        data.extend_from_slice(&37774900i32.to_le_bytes()); // lat
+        data.extend_from_slice(&(-122419400i32).to_le_bytes()); // lon
+        assert_eq!(data.len(), ADVERT_RESP_LATLON_MIN_LEN);
+
+        let resp = parse_advert_response(&data).unwrap();
+        assert_eq!(resp.lat, Some(37774900));
+        assert_eq!(resp.lon, Some(-122419400));
+        assert!(resp.node_desc.is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_with_latlon_and_desc() {
+        let mut data = build_advert_response_payload();
+        data.extend_from_slice(&37774900i32.to_le_bytes()); // lat
+        data.extend_from_slice(&(-122419400i32).to_le_bytes()); // lon
+        let mut desc = [0u8; 32];
+        desc[..6].copy_from_slice(b"Relay1");
+        data.extend_from_slice(&desc); // node_desc
+
+        let resp = parse_advert_response(&data).unwrap();
+        assert_eq!(resp.lat, Some(37774900));
+        assert_eq!(resp.lon, Some(-122419400));
+        assert_eq!(resp.node_desc.as_deref(), Some("Relay1"));
+    }
+
+    #[test]
+    fn test_parse_advert_response_partial_latlon_ignored() {
+        // Payload extends past flags but not enough for both lat and lon
+        let mut data = build_advert_response_payload();
+        data.extend_from_slice(&[0xFF; 4]); // only 4 extra bytes, need 8
+
+        let resp = parse_advert_response(&data).unwrap();
+        // Not enough for lat+lon, so they remain None
+        assert!(resp.lat.is_none());
+        assert!(resp.lon.is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_latlon_exact_no_desc() {
+        // Exactly at LATLON_MIN_LEN: lat+lon present but no description
+        let mut data = build_advert_response_payload();
+        data.extend_from_slice(&0i32.to_le_bytes()); // lat = 0
+        data.extend_from_slice(&0i32.to_le_bytes()); // lon = 0
+
+        let resp = parse_advert_response(&data).unwrap();
+        assert_eq!(resp.lat, Some(0));
+        assert_eq!(resp.lon, Some(0));
+        assert!(resp.node_desc.is_none());
+    }
+
+    #[test]
+    fn test_parse_advert_response_offset_constants() {
+        // Verify the computed constants match the documented byte layout
+        assert_eq!(ADVERT_RESP_TAG_OFFSET, 0);
+        assert_eq!(ADVERT_RESP_PUBKEY_OFFSET, 4);
+        assert_eq!(ADVERT_RESP_ADV_TYPE_OFFSET, 36);
+        assert_eq!(ADVERT_RESP_NODE_NAME_OFFSET, 37);
+        assert_eq!(ADVERT_RESP_TIMESTAMP_OFFSET, 69);
+        assert_eq!(ADVERT_RESP_FLAGS_OFFSET, 73);
+        assert_eq!(ADVERT_RESP_MIN_LEN, 74);
+        assert_eq!(ADVERT_RESP_LAT_OFFSET, 74);
+        assert_eq!(ADVERT_RESP_LON_OFFSET, 78);
+        assert_eq!(ADVERT_RESP_LATLON_MIN_LEN, 82);
+        assert_eq!(ADVERT_RESP_NODE_DESC_OFFSET, 82);
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1119,6 +1119,24 @@ pub fn parse_discover_response(payload: &[u8]) -> Vec<DiscoverEntry> {
     entries
 }
 
+// --- ContactEnd payload layout ---
+
+/// Minimum length for a ContactEnd payload to contain a
+/// `last_modification_timestamp`.
+const CONTACT_END_TIMESTAMP_LEN: usize = 4;
+
+/// Parse the optional `last_modification_timestamp` from a
+/// `PacketType::ContactEnd` payload.
+///
+/// Returns `0` if the payload is too short to contain the timestamp.
+pub fn parse_contact_end_timestamp(payload: &[u8]) -> u32 {
+    if payload.len() >= CONTACT_END_TIMESTAMP_LEN {
+        read_u32_le(payload, 0).unwrap_or(0)
+    } else {
+        0
+    }
+}
+
 // --- StatusResponse payload layout ---
 
 /// Length of the sender prefix in a StatusResponse payload.
@@ -2533,5 +2551,30 @@ mod tests {
         assert_eq!(BINARY_RESP_TAG_OFFSET, 1);
         assert_eq!(BINARY_RESP_DATA_OFFSET, 5);
         assert_eq!(BINARY_RESP_MIN_LEN, 5);
+    }
+
+    // ========== parse_contact_end_timestamp tests ==========
+
+    #[test]
+    fn test_parse_contact_end_timestamp_empty() {
+        assert_eq!(parse_contact_end_timestamp(&[]), 0);
+    }
+
+    #[test]
+    fn test_parse_contact_end_timestamp_too_short() {
+        assert_eq!(parse_contact_end_timestamp(&[0x01, 0x02, 0x03]), 0);
+    }
+
+    #[test]
+    fn test_parse_contact_end_timestamp_valid() {
+        let data = 1700000000u32.to_le_bytes();
+        assert_eq!(parse_contact_end_timestamp(&data), 1700000000);
+    }
+
+    #[test]
+    fn test_parse_contact_end_timestamp_with_extra_bytes() {
+        let mut data = 42u32.to_le_bytes().to_vec();
+        data.extend_from_slice(&[0xFF, 0xFF]); // extra trailing bytes
+        assert_eq!(parse_contact_end_timestamp(&data), 42);
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,5 +1,7 @@
 //! Binary parsing utilities for MeshCore protocol
 
+use std::collections::HashMap;
+
 use crate::error::Error;
 use crate::events::{
     AclEntry, AdvertResponseData, AdvertisementData, BatteryInfo, ChannelInfoData, ChannelMessage,
@@ -1115,6 +1117,129 @@ pub fn parse_discover_response(payload: &[u8]) -> Vec<DiscoverEntry> {
         offset += DISCOVER_ENTRY_LEN;
     }
     entries
+}
+
+// --- StatusResponse payload layout ---
+
+/// Length of the sender prefix in a StatusResponse payload.
+const STATUS_RESP_PREFIX_LEN: usize = 6;
+/// Minimum length for a StatusResponse payload (prefix + status data).
+const STATUS_RESP_MIN_LEN: usize = 58;
+
+/// Parsed status response: sender prefix and status data.
+pub struct StatusResponseFrame {
+    /// 6-byte public key prefix of the sender.
+    pub sender_prefix: [u8; 6],
+    /// Parsed status data.
+    pub status: StatusData,
+}
+
+/// Parse a [`StatusResponseFrame`] from a `PacketType::StatusResponse`
+/// payload.
+///
+/// Returns `None` if the payload is too short or the status data cannot
+/// be parsed.
+pub fn parse_status_response(payload: &[u8]) -> Option<StatusResponseFrame> {
+    if payload.len() < STATUS_RESP_MIN_LEN {
+        return None;
+    }
+
+    let sender_prefix: [u8; 6] = read_bytes(payload, 0).ok()?;
+    let status = parse_status(&payload[STATUS_RESP_PREFIX_LEN..], sender_prefix).ok()?;
+
+    Some(StatusResponseFrame {
+        sender_prefix,
+        status,
+    })
+}
+
+// --- TelemetryResponse payload layout ---
+
+/// Minimum length for a TelemetryResponse payload (4-byte tag).
+const TELEMETRY_RESP_MIN_LEN: usize = 4;
+/// Offset where the LPP telemetry data begins.
+const TELEMETRY_RESP_DATA_OFFSET: usize = 4;
+
+/// Parsed telemetry response: tag and LPP data.
+pub struct TelemetryResponseFrame {
+    /// The 4-byte request tag.
+    pub tag: [u8; 4],
+    /// LPP telemetry data.
+    pub data: Vec<u8>,
+}
+
+/// Parse a [`TelemetryResponseFrame`] from a
+/// `PacketType::TelemetryResponse` payload.
+///
+/// Returns `None` if the payload is too short.
+pub fn parse_telemetry_response(payload: &[u8]) -> Option<TelemetryResponseFrame> {
+    if payload.len() < TELEMETRY_RESP_MIN_LEN {
+        return None;
+    }
+
+    let tag: [u8; 4] = read_bytes(payload, 0).ok()?;
+    let data = payload[TELEMETRY_RESP_DATA_OFFSET..].to_vec();
+
+    Some(TelemetryResponseFrame { tag, data })
+}
+
+// --- CustomVars payload ---
+
+/// Parse custom variables from a `PacketType::CustomVars` payload.
+///
+/// The payload is UTF-8 text with `key=value` pairs separated by
+/// newlines.
+pub fn parse_custom_vars(payload: &[u8]) -> HashMap<String, String> {
+    let mut vars = HashMap::new();
+    let text = String::from_utf8_lossy(payload);
+    for line in text.lines() {
+        if let Some((key, value)) = line.split_once('=') {
+            vars.insert(key.to_string(), value.to_string());
+        }
+    }
+    vars
+}
+
+// --- BinaryResponse frame layout ---
+//
+// Firmware layout: [subtype: 1][tag: 4][data...]
+// The subtype byte is skipped; the tag lives at offset 1 and the
+// response data starts at offset 5.
+
+/// Length of the subtype byte that precedes the tag.
+const BINARY_RESP_SUBTYPE_LEN: usize = 1;
+/// Length of the 4-byte request tag echoed back in the response.
+const BINARY_RESP_TAG_LEN: usize = 4;
+/// Offset of the tag within the BinaryResponse payload.
+const BINARY_RESP_TAG_OFFSET: usize = BINARY_RESP_SUBTYPE_LEN;
+/// Offset where the response data begins.
+const BINARY_RESP_DATA_OFFSET: usize = BINARY_RESP_TAG_OFFSET + BINARY_RESP_TAG_LEN;
+/// Minimum payload length (subtype + tag).
+const BINARY_RESP_MIN_LEN: usize = BINARY_RESP_DATA_OFFSET;
+
+/// Parsed binary response frame: tag and data extracted from the raw
+/// `PacketType::BinaryResponse` payload.
+pub struct BinaryResponseFrame {
+    /// The 4-byte request tag echoed by the firmware.
+    pub tag: [u8; 4],
+    /// The response data (everything after the tag).
+    pub data: Vec<u8>,
+}
+
+/// Parse the frame envelope of a `PacketType::BinaryResponse` payload,
+/// extracting the tag and data.
+///
+/// Returns `None` if the payload is too short to contain the subtype
+/// byte and the 4-byte tag.
+pub fn parse_binary_response_frame(payload: &[u8]) -> Option<BinaryResponseFrame> {
+    if payload.len() < BINARY_RESP_MIN_LEN {
+        return None;
+    }
+
+    let tag: [u8; 4] = read_bytes(payload, BINARY_RESP_TAG_OFFSET).ok()?;
+    let data = payload[BINARY_RESP_DATA_OFFSET..].to_vec();
+
+    Some(BinaryResponseFrame { tag, data })
 }
 
 #[cfg(test)]
@@ -2294,5 +2419,119 @@ mod tests {
         let data = vec![0u8; 37];
         let entries = parse_discover_response(&data);
         assert!(entries.is_empty());
+    }
+
+    // ========== parse_status_response tests ==========
+
+    #[test]
+    fn test_parse_status_response_too_short() {
+        assert!(parse_status_response(&[]).is_none());
+        assert!(parse_status_response(&[0; 57]).is_none());
+    }
+
+    #[test]
+    fn test_parse_status_response_valid() {
+        // Build a valid StatusResponse payload: 6-byte prefix + status data
+        let mut data = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66]; // sender prefix
+                                                                 // Status data: battery_mv(2) + tx_queue(2) + noise(2) + rssi(2) + recv(4)
+                                                                 // + sent(4) + airtime(4) + uptime(4) + flood(4) + direct(4) + snr(1)
+                                                                 // + dup(4) + rx_airtime(4) + padding... = at least 52 bytes
+        let mut status_data = vec![0u8; 52];
+        // battery_mv = 3700 at offset 0
+        status_data[0..2].copy_from_slice(&3700u16.to_le_bytes());
+        data.extend_from_slice(&status_data);
+        let frame = parse_status_response(&data).unwrap();
+        assert_eq!(frame.sender_prefix, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        assert_eq!(frame.status.battery_mv, 3700);
+    }
+
+    // ========== parse_telemetry_response tests ==========
+
+    #[test]
+    fn test_parse_telemetry_response_too_short() {
+        assert!(parse_telemetry_response(&[]).is_none());
+        assert!(parse_telemetry_response(&[0; 3]).is_none());
+    }
+
+    #[test]
+    fn test_parse_telemetry_response_tag_only() {
+        let data = [0xAA, 0xBB, 0xCC, 0xDD];
+        let frame = parse_telemetry_response(&data).unwrap();
+        assert_eq!(frame.tag, [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert!(frame.data.is_empty());
+    }
+
+    #[test]
+    fn test_parse_telemetry_response_with_data() {
+        let mut data = vec![0x01, 0x02, 0x03, 0x04]; // tag
+        data.extend_from_slice(&[0x10, 0x20, 0x30]); // LPP data
+        let frame = parse_telemetry_response(&data).unwrap();
+        assert_eq!(frame.tag, [0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(frame.data, vec![0x10, 0x20, 0x30]);
+    }
+
+    // ========== parse_custom_vars tests ==========
+
+    #[test]
+    fn test_parse_custom_vars_empty() {
+        let vars = parse_custom_vars(&[]);
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn test_parse_custom_vars_single() {
+        let vars = parse_custom_vars(b"key=value");
+        assert_eq!(vars.get("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_parse_custom_vars_multiple() {
+        let vars = parse_custom_vars(b"a=1\nb=2\nc=3");
+        assert_eq!(vars.len(), 3);
+        assert_eq!(vars.get("a").unwrap(), "1");
+        assert_eq!(vars.get("b").unwrap(), "2");
+        assert_eq!(vars.get("c").unwrap(), "3");
+    }
+
+    #[test]
+    fn test_parse_custom_vars_no_equals_skipped() {
+        let vars = parse_custom_vars(b"good=yes\nbadline\nalso=ok");
+        assert_eq!(vars.len(), 2);
+        assert_eq!(vars.get("good").unwrap(), "yes");
+        assert_eq!(vars.get("also").unwrap(), "ok");
+    }
+
+    // ========== parse_binary_response_frame tests ==========
+
+    #[test]
+    fn test_parse_binary_response_frame_too_short() {
+        assert!(parse_binary_response_frame(&[]).is_none());
+        assert!(parse_binary_response_frame(&[0; 4]).is_none());
+    }
+
+    #[test]
+    fn test_parse_binary_response_frame_minimal() {
+        // subtype(1) + tag(4) = 5 bytes, no data
+        let data = [0xFF, 0x01, 0x02, 0x03, 0x04];
+        let frame = parse_binary_response_frame(&data).unwrap();
+        assert_eq!(frame.tag, [0x01, 0x02, 0x03, 0x04]);
+        assert!(frame.data.is_empty());
+    }
+
+    #[test]
+    fn test_parse_binary_response_frame_with_data() {
+        let mut data = vec![0x00]; // subtype (skipped)
+        data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // tag
+        data.extend_from_slice(&[0x11, 0x22, 0x33]); // response data
+        let frame = parse_binary_response_frame(&data).unwrap();
+        assert_eq!(frame.tag, [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(frame.data, vec![0x11, 0x22, 0x33]);
+    }
+
+    #[test]
+    fn test_parse_binary_response_frame_constants() {
+        assert_eq!(BINARY_RESP_TAG_OFFSET, 1);
+        assert_eq!(BINARY_RESP_DATA_OFFSET, 5);
+        assert_eq!(BINARY_RESP_MIN_LEN, 5);
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -933,7 +933,7 @@ pub fn parse_msg_sent(payload: &[u8]) -> Option<MsgSentInfo> {
         return None;
     }
 
-    let message_type = payload[0];
+    let message_type = payload[0]; // jonesy:allow(bounds) -- checked >= MSG_SENT_MIN_LEN above
     let expected_ack: [u8; 4] = read_bytes(payload, MSG_SENT_ACK_OFFSET).ok()?;
     let suggested_timeout = read_u32_le(payload, MSG_SENT_TIMEOUT_OFFSET).unwrap_or(5000);
 
@@ -958,7 +958,7 @@ pub fn parse_channel_info(payload: &[u8]) -> Option<ChannelInfoData> {
         return None;
     }
 
-    let channel_idx = payload[0];
+    let channel_idx = payload[0]; // jonesy:allow(bounds) -- checked >= min_len above
     let name = read_string(payload, 1, CHANNEL_NAME_LEN);
     let secret: [u8; CHANNEL_SECRET_LEN] =
         read_bytes(payload, 1 + CHANNEL_NAME_LEN).unwrap_or([0; CHANNEL_SECRET_LEN]);
@@ -982,6 +982,7 @@ pub fn parse_stats(payload: &[u8]) -> Option<StatsData> {
     }
 
     let category = match payload[0] {
+        // jonesy:allow(bounds) -- checked !is_empty() above
         0 => StatsCategory::Core,
         1 => StatsCategory::Radio,
         2 => StatsCategory::Packets,
@@ -1054,7 +1055,7 @@ pub fn parse_path_update(payload: &[u8]) -> Option<PathUpdateData> {
     }
 
     let prefix: [u8; 6] = read_bytes(payload, 0).ok()?;
-    let path_len = payload[PATH_UPDATE_PATH_LEN_OFFSET] as i8;
+    let path_len = payload[PATH_UPDATE_PATH_LEN_OFFSET] as i8; // jonesy:allow(bounds) -- checked >= PATH_UPDATE_MIN_LEN above
     let path = if payload.len() > PATH_UPDATE_PATH_OFFSET {
         payload[PATH_UPDATE_PATH_OFFSET..].to_vec()
     } else {
@@ -1082,11 +1083,12 @@ pub fn parse_trace_data(payload: &[u8]) -> TraceInfo {
     let mut hops = Vec::new();
     let mut offset = 0;
     while offset + TRACE_HOP_LEN <= payload.len() {
+        // jonesy:allow(overflow)
         let prefix: [u8; 6] = read_bytes(payload, offset).unwrap_or([0; 6]);
-        let snr_raw = payload[offset + TRACE_HOP_SNR_OFFSET] as i8;
+        let snr_raw = payload[offset + TRACE_HOP_SNR_OFFSET] as i8; // jonesy:allow(bounds, overflow) -- loop guard ensures offset + 7 <= len
         let snr = snr_raw as f32 / 4.0;
         hops.push(TraceHop { prefix, snr });
-        offset += TRACE_HOP_LEN;
+        offset += TRACE_HOP_LEN; // jonesy:allow(overflow) -- bounded by payload.len()
     }
     TraceInfo { hops }
 }
@@ -1111,10 +1113,11 @@ pub fn parse_discover_response(payload: &[u8]) -> Vec<DiscoverEntry> {
     let mut entries = Vec::new();
     let mut offset = 0;
     while offset + DISCOVER_ENTRY_MIN_LEN <= payload.len() {
-        let pubkey = payload[offset..offset + DISCOVER_NAME_OFFSET].to_vec();
-        let name = read_string(payload, offset + DISCOVER_NAME_OFFSET, DISCOVER_NAME_LEN);
+        // jonesy:allow(overflow)
+        let pubkey = payload[offset..offset + DISCOVER_NAME_OFFSET].to_vec(); // jonesy:allow(overflow)
+        let name = read_string(payload, offset + DISCOVER_NAME_OFFSET, DISCOVER_NAME_LEN); // jonesy:allow(overflow)
         entries.push(DiscoverEntry { pubkey, name });
-        offset += DISCOVER_ENTRY_LEN;
+        offset += DISCOVER_ENTRY_LEN; // jonesy:allow(overflow) -- bounded by payload.len()
     }
     entries
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -2,11 +2,13 @@
 
 use crate::error::Error;
 use crate::events::{
-    AclEntry, AdvertResponseData, ChannelMessage, Contact, ContactMessage, DeviceInfoData,
-    MeshPacketHeader, MmaEntry, Neighbour, NeighboursData, RawAdvertisement, SelfInfo, StatusData,
+    AclEntry, AdvertResponseData, AdvertisementData, BatteryInfo, ChannelInfoData, ChannelMessage,
+    Contact, ContactMessage, DeviceInfoData, DiscoverEntry, MeshPacketHeader, MmaEntry,
+    MsgSentInfo, Neighbour, NeighboursData, PathUpdateData, RawAdvertisement, SelfInfo,
+    StatsCategory, StatsData, StatusData, TraceHop, TraceInfo,
 };
 use crate::packets::{PayloadType, RouteType};
-use crate::Result;
+use crate::{Result, CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
 
 /// Read a little-endian u16 from a byte slice
 pub fn read_u16_le(data: &[u8], offset: usize) -> Result<u16> {
@@ -878,6 +880,241 @@ pub fn parse_advert_response(payload: &[u8]) -> Option<AdvertResponseData> {
         lon,
         node_desc,
     })
+}
+
+// --- Battery payload layout ---
+
+/// Minimum length for a Battery payload (just the voltage field).
+const BATTERY_MIN_LEN: usize = 2;
+/// Minimum length to include optional storage fields (used_kb + total_kb).
+const BATTERY_STORAGE_MIN_LEN: usize = 10;
+const BATTERY_USED_KB_OFFSET: usize = 2;
+const BATTERY_TOTAL_KB_OFFSET: usize = 6;
+
+/// Parse a [`BatteryInfo`] from a `PacketType::Battery` payload.
+///
+/// Returns `None` if the payload is too short to contain the voltage field.
+pub fn parse_battery(payload: &[u8]) -> Option<BatteryInfo> {
+    if payload.len() < BATTERY_MIN_LEN {
+        return None;
+    }
+
+    let battery_mv = read_u16_le(payload, 0).ok()?;
+    let (used_kb, total_kb) = if payload.len() >= BATTERY_STORAGE_MIN_LEN {
+        (
+            Some(read_u32_le(payload, BATTERY_USED_KB_OFFSET).unwrap_or(0)),
+            Some(read_u32_le(payload, BATTERY_TOTAL_KB_OFFSET).unwrap_or(0)),
+        )
+    } else {
+        (None, None)
+    };
+
+    Some(BatteryInfo {
+        battery_mv,
+        used_kb,
+        total_kb,
+    })
+}
+
+// --- MsgSent payload layout ---
+
+/// Minimum length for a MsgSent payload.
+const MSG_SENT_MIN_LEN: usize = 9;
+const MSG_SENT_ACK_OFFSET: usize = 1;
+const MSG_SENT_TIMEOUT_OFFSET: usize = 5;
+
+/// Parse a [`MsgSentInfo`] from a `PacketType::MsgSent` payload.
+///
+/// Returns `None` if the payload is too short.
+pub fn parse_msg_sent(payload: &[u8]) -> Option<MsgSentInfo> {
+    if payload.len() < MSG_SENT_MIN_LEN {
+        return None;
+    }
+
+    let message_type = payload[0];
+    let expected_ack: [u8; 4] = read_bytes(payload, MSG_SENT_ACK_OFFSET).ok()?;
+    let suggested_timeout = read_u32_le(payload, MSG_SENT_TIMEOUT_OFFSET).unwrap_or(5000);
+
+    Some(MsgSentInfo {
+        message_type,
+        expected_ack,
+        suggested_timeout,
+    })
+}
+
+// --- ChannelInfo payload layout ---
+
+/// Parse a [`ChannelInfoData`] from a `PacketType::ChannelInfo` payload.
+///
+/// The firmware always sends `CHANNEL_INFO_LEN` bytes:
+/// 1 (idx) + CHANNEL_NAME_LEN (name) + CHANNEL_SECRET_LEN (secret).
+///
+/// Returns `None` if the payload is too short.
+pub fn parse_channel_info(payload: &[u8]) -> Option<ChannelInfoData> {
+    let min_len = 1 + CHANNEL_NAME_LEN + CHANNEL_SECRET_LEN;
+    if payload.len() < min_len {
+        return None;
+    }
+
+    let channel_idx = payload[0];
+    let name = read_string(payload, 1, CHANNEL_NAME_LEN);
+    let secret: [u8; CHANNEL_SECRET_LEN] =
+        read_bytes(payload, 1 + CHANNEL_NAME_LEN).unwrap_or([0; CHANNEL_SECRET_LEN]);
+
+    Some(ChannelInfoData {
+        channel_idx,
+        name,
+        secret,
+    })
+}
+
+// --- Stats payload layout ---
+
+/// Parse a [`StatsData`] (with its [`StatsCategory`]) from a
+/// `PacketType::Stats` payload.
+///
+/// Returns `None` if the payload is empty.
+pub fn parse_stats(payload: &[u8]) -> Option<StatsData> {
+    if payload.is_empty() {
+        return None;
+    }
+
+    let category = match payload[0] {
+        0 => StatsCategory::Core,
+        1 => StatsCategory::Radio,
+        2 => StatsCategory::Packets,
+        _ => StatsCategory::Core,
+    };
+
+    Some(StatsData {
+        category,
+        raw: payload[1..].to_vec(),
+    })
+}
+
+// --- Advertisement payload layout ---
+
+/// Length of the advertiser's 6-byte public key prefix.
+const ADVERT_PREFIX_LEN: usize = 6;
+/// Fixed width of the advertisement name field.
+const ADVERT_NAME_LEN: usize = 32;
+/// Minimum payload length (prefix + name header).
+const ADVERT_MIN_LEN: usize = ADVERT_PREFIX_LEN + 8; // prefix(6) + at least some name bytes
+const ADVERT_NAME_OFFSET: usize = ADVERT_PREFIX_LEN;
+/// Offset of the optional latitude field.
+const ADVERT_LAT_OFFSET: usize = ADVERT_NAME_OFFSET + ADVERT_NAME_LEN;
+/// Offset of the optional longitude field.
+const ADVERT_LON_OFFSET: usize = ADVERT_LAT_OFFSET + 4;
+
+/// Parse an [`AdvertisementData`] from a `PacketType::Advertisement` payload.
+///
+/// Returns `None` if the payload is too short to contain the prefix and
+/// at least part of the name.
+pub fn parse_advertisement(payload: &[u8]) -> Option<AdvertisementData> {
+    if payload.len() < ADVERT_MIN_LEN {
+        return None;
+    }
+
+    let prefix: [u8; 6] = read_bytes(payload, 0).ok()?;
+    let name = read_string(payload, ADVERT_NAME_OFFSET, ADVERT_NAME_LEN);
+    let lat = if payload.len() >= ADVERT_LAT_OFFSET + 4 {
+        read_i32_le(payload, ADVERT_LAT_OFFSET).unwrap_or(0)
+    } else {
+        0
+    };
+    let lon = if payload.len() >= ADVERT_LON_OFFSET + 4 {
+        read_i32_le(payload, ADVERT_LON_OFFSET).unwrap_or(0)
+    } else {
+        0
+    };
+
+    Some(AdvertisementData {
+        prefix,
+        name,
+        lat,
+        lon,
+    })
+}
+
+// --- PathUpdate payload layout ---
+
+/// Minimum length for a PathUpdate payload (prefix + path_len byte).
+const PATH_UPDATE_MIN_LEN: usize = 7;
+const PATH_UPDATE_PATH_LEN_OFFSET: usize = 6;
+const PATH_UPDATE_PATH_OFFSET: usize = 7;
+
+/// Parse a [`PathUpdateData`] from a `PacketType::PathUpdate` payload.
+///
+/// Returns `None` if the payload is too short.
+pub fn parse_path_update(payload: &[u8]) -> Option<PathUpdateData> {
+    if payload.len() < PATH_UPDATE_MIN_LEN {
+        return None;
+    }
+
+    let prefix: [u8; 6] = read_bytes(payload, 0).ok()?;
+    let path_len = payload[PATH_UPDATE_PATH_LEN_OFFSET] as i8;
+    let path = if payload.len() > PATH_UPDATE_PATH_OFFSET {
+        payload[PATH_UPDATE_PATH_OFFSET..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    Some(PathUpdateData {
+        prefix,
+        path_len,
+        path,
+    })
+}
+
+// --- TraceData payload layout ---
+
+/// Size of each trace hop entry (6-byte prefix + 1-byte SNR).
+const TRACE_HOP_LEN: usize = 7;
+/// Offset of the SNR byte within a hop entry.
+const TRACE_HOP_SNR_OFFSET: usize = 6;
+
+/// Parse a [`TraceInfo`] from a `PacketType::TraceData` payload.
+///
+/// Returns a (possibly empty) list of trace hops.
+pub fn parse_trace_data(payload: &[u8]) -> TraceInfo {
+    let mut hops = Vec::new();
+    let mut offset = 0;
+    while offset + TRACE_HOP_LEN <= payload.len() {
+        let prefix: [u8; 6] = read_bytes(payload, offset).unwrap_or([0; 6]);
+        let snr_raw = payload[offset + TRACE_HOP_SNR_OFFSET] as i8;
+        let snr = snr_raw as f32 / 4.0;
+        hops.push(TraceHop { prefix, snr });
+        offset += TRACE_HOP_LEN;
+    }
+    TraceInfo { hops }
+}
+
+// --- ControlData / DiscoverResponse layout ---
+
+/// Size of one discover entry (32-byte pubkey + 32-byte name).
+const DISCOVER_ENTRY_LEN: usize = 64;
+/// Minimum readable portion of an entry (pubkey + at least some name).
+const DISCOVER_ENTRY_MIN_LEN: usize = 38;
+/// Offset of the name within an entry.
+const DISCOVER_NAME_OFFSET: usize = 32;
+/// Maximum name length in a discover entry.
+const DISCOVER_NAME_LEN: usize = 32;
+
+/// Parse a list of [`DiscoverEntry`] from a
+/// `ControlType::NodeDiscoverResp` payload.
+///
+/// The `payload` should start *after* the control-type byte (i.e. at the
+/// first entry).
+pub fn parse_discover_response(payload: &[u8]) -> Vec<DiscoverEntry> {
+    let mut entries = Vec::new();
+    let mut offset = 0;
+    while offset + DISCOVER_ENTRY_MIN_LEN <= payload.len() {
+        let pubkey = payload[offset..offset + DISCOVER_NAME_OFFSET].to_vec();
+        let name = read_string(payload, offset + DISCOVER_NAME_OFFSET, DISCOVER_NAME_LEN);
+        entries.push(DiscoverEntry { pubkey, name });
+        offset += DISCOVER_ENTRY_LEN;
+    }
+    entries
 }
 
 #[cfg(test)]
@@ -1779,5 +2016,283 @@ mod tests {
         assert_eq!(ADVERT_RESP_LON_OFFSET, 78);
         assert_eq!(ADVERT_RESP_LATLON_MIN_LEN, 82);
         assert_eq!(ADVERT_RESP_NODE_DESC_OFFSET, 82);
+    }
+
+    // ========== parse_battery tests ==========
+
+    #[test]
+    fn test_parse_battery_too_short() {
+        assert!(parse_battery(&[]).is_none());
+        assert!(parse_battery(&[0x01]).is_none());
+    }
+
+    #[test]
+    fn test_parse_battery_voltage_only() {
+        let data = 3700u16.to_le_bytes();
+        let info = parse_battery(&data).unwrap();
+        assert_eq!(info.battery_mv, 3700);
+        assert!(info.used_kb.is_none());
+        assert!(info.total_kb.is_none());
+    }
+
+    #[test]
+    fn test_parse_battery_with_storage() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&3800u16.to_le_bytes());
+        data.extend_from_slice(&1024u32.to_le_bytes()); // used_kb
+        data.extend_from_slice(&4096u32.to_le_bytes()); // total_kb
+        let info = parse_battery(&data).unwrap();
+        assert_eq!(info.battery_mv, 3800);
+        assert_eq!(info.used_kb, Some(1024));
+        assert_eq!(info.total_kb, Some(4096));
+    }
+
+    #[test]
+    fn test_parse_battery_partial_storage_ignored() {
+        // 2 bytes voltage + 4 bytes used_kb, but no total_kb (6 bytes < 10)
+        let mut data = Vec::new();
+        data.extend_from_slice(&3500u16.to_le_bytes());
+        data.extend_from_slice(&512u32.to_le_bytes());
+        let info = parse_battery(&data).unwrap();
+        assert_eq!(info.battery_mv, 3500);
+        assert!(info.used_kb.is_none());
+        assert!(info.total_kb.is_none());
+    }
+
+    // ========== parse_msg_sent tests ==========
+
+    #[test]
+    fn test_parse_msg_sent_too_short() {
+        assert!(parse_msg_sent(&[]).is_none());
+        assert!(parse_msg_sent(&[0; 8]).is_none());
+    }
+
+    #[test]
+    fn test_parse_msg_sent_valid() {
+        let mut data = vec![0x02]; // message_type
+        data.extend_from_slice(&[0xAA, 0xBB, 0xCC, 0xDD]); // expected_ack
+        data.extend_from_slice(&10000u32.to_le_bytes()); // suggested_timeout
+        let info = parse_msg_sent(&data).unwrap();
+        assert_eq!(info.message_type, 0x02);
+        assert_eq!(info.expected_ack, [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(info.suggested_timeout, 10000);
+    }
+
+    // ========== parse_channel_info tests ==========
+
+    #[test]
+    fn test_parse_channel_info_too_short() {
+        assert!(parse_channel_info(&[]).is_none());
+        assert!(parse_channel_info(&[0; 48]).is_none()); // need 49
+    }
+
+    #[test]
+    fn test_parse_channel_info_valid() {
+        let mut data = vec![3u8]; // channel_idx
+        let mut name = [0u8; CHANNEL_NAME_LEN];
+        name[..4].copy_from_slice(b"Test");
+        data.extend_from_slice(&name);
+        data.extend_from_slice(&[0xCC; CHANNEL_SECRET_LEN]);
+        let info = parse_channel_info(&data).unwrap();
+        assert_eq!(info.channel_idx, 3);
+        assert_eq!(info.name, "Test");
+        assert_eq!(info.secret, [0xCC; CHANNEL_SECRET_LEN]);
+    }
+
+    // ========== parse_stats tests ==========
+
+    #[test]
+    fn test_parse_stats_empty() {
+        assert!(parse_stats(&[]).is_none());
+    }
+
+    #[test]
+    fn test_parse_stats_core() {
+        let data = [0, 0x11, 0x22];
+        let stats = parse_stats(&data).unwrap();
+        assert_eq!(stats.category, StatsCategory::Core);
+        assert_eq!(stats.raw, vec![0x11, 0x22]);
+    }
+
+    #[test]
+    fn test_parse_stats_radio() {
+        let data = [1, 0xAA];
+        let stats = parse_stats(&data).unwrap();
+        assert_eq!(stats.category, StatsCategory::Radio);
+    }
+
+    #[test]
+    fn test_parse_stats_packets() {
+        let data = [2];
+        let stats = parse_stats(&data).unwrap();
+        assert_eq!(stats.category, StatsCategory::Packets);
+        assert!(stats.raw.is_empty());
+    }
+
+    #[test]
+    fn test_parse_stats_unknown_defaults_to_core() {
+        let data = [99, 0xFF];
+        let stats = parse_stats(&data).unwrap();
+        assert_eq!(stats.category, StatsCategory::Core);
+    }
+
+    // ========== parse_advertisement tests ==========
+
+    #[test]
+    fn test_parse_advertisement_too_short() {
+        assert!(parse_advertisement(&[]).is_none());
+        assert!(parse_advertisement(&[0; 13]).is_none());
+    }
+
+    #[test]
+    fn test_parse_advertisement_minimal() {
+        let mut data = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06]; // prefix
+        let mut name = [0u8; 32];
+        name[..4].copy_from_slice(b"Node");
+        data.extend_from_slice(&name);
+        // No lat/lon
+        let advert = parse_advertisement(&data).unwrap();
+        assert_eq!(advert.prefix, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(advert.name, "Node");
+        assert_eq!(advert.lat, 0);
+        assert_eq!(advert.lon, 0);
+    }
+
+    #[test]
+    fn test_parse_advertisement_with_latlon() {
+        let mut data = vec![0xAA; 6]; // prefix
+        let mut name = [0u8; 32];
+        name[..5].copy_from_slice(b"Hello");
+        data.extend_from_slice(&name);
+        data.extend_from_slice(&37774900i32.to_le_bytes()); // lat
+        data.extend_from_slice(&(-122419400i32).to_le_bytes()); // lon
+        let advert = parse_advertisement(&data).unwrap();
+        assert_eq!(advert.name, "Hello");
+        assert_eq!(advert.lat, 37774900);
+        assert_eq!(advert.lon, -122419400);
+    }
+
+    // ========== parse_path_update tests ==========
+
+    #[test]
+    fn test_parse_path_update_too_short() {
+        assert!(parse_path_update(&[]).is_none());
+        assert!(parse_path_update(&[0; 6]).is_none());
+    }
+
+    #[test]
+    fn test_parse_path_update_no_path() {
+        let mut data = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66]; // prefix
+        data.push(0x03); // path_len = 3
+        let update = parse_path_update(&data).unwrap();
+        assert_eq!(update.prefix, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        assert_eq!(update.path_len, 3);
+        assert!(update.path.is_empty());
+    }
+
+    #[test]
+    fn test_parse_path_update_with_path() {
+        let mut data = vec![0xAA; 6]; // prefix
+        data.push(0x02); // path_len = 2
+        data.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let update = parse_path_update(&data).unwrap();
+        assert_eq!(update.path_len, 2);
+        assert_eq!(update.path, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn test_parse_path_update_negative_path_len() {
+        let mut data = vec![0xBB; 6]; // prefix
+        data.push(0xFF); // path_len as i8 = -1 (flood)
+        let update = parse_path_update(&data).unwrap();
+        assert_eq!(update.path_len, -1);
+    }
+
+    // ========== parse_trace_data tests ==========
+
+    #[test]
+    fn test_parse_trace_data_empty() {
+        let trace = parse_trace_data(&[]);
+        assert!(trace.hops.is_empty());
+    }
+
+    #[test]
+    fn test_parse_trace_data_single_hop() {
+        let mut data = vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06]; // prefix
+        data.push(40); // snr_raw = 40, snr = 10.0
+        let trace = parse_trace_data(&data);
+        assert_eq!(trace.hops.len(), 1);
+        assert_eq!(trace.hops[0].prefix, [0x01, 0x02, 0x03, 0x04, 0x05, 0x06]);
+        assert_eq!(trace.hops[0].snr, 10.0);
+    }
+
+    #[test]
+    fn test_parse_trace_data_multiple_hops() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&[0xAA; 6]);
+        data.push(20); // snr = 5.0
+        data.extend_from_slice(&[0xBB; 6]);
+        data.push((-8i8) as u8); // snr = -2.0
+        let trace = parse_trace_data(&data);
+        assert_eq!(trace.hops.len(), 2);
+        assert_eq!(trace.hops[0].snr, 5.0);
+        assert_eq!(trace.hops[1].snr, -2.0);
+    }
+
+    #[test]
+    fn test_parse_trace_data_trailing_bytes_ignored() {
+        // 7 bytes for one hop + 3 trailing bytes (not enough for another hop)
+        let mut data = vec![0xCC; 6];
+        data.push(0);
+        data.extend_from_slice(&[0xFF, 0xFF, 0xFF]); // trailing
+        let trace = parse_trace_data(&data);
+        assert_eq!(trace.hops.len(), 1);
+    }
+
+    // ========== parse_discover_response tests ==========
+
+    #[test]
+    fn test_parse_discover_response_empty() {
+        let entries = parse_discover_response(&[]);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_parse_discover_response_single_entry() {
+        let mut data = vec![0xAA; 32]; // pubkey
+        let mut name = [0u8; 32];
+        name[..5].copy_from_slice(b"Peer1");
+        data.extend_from_slice(&name);
+        let entries = parse_discover_response(&data);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].pubkey, vec![0xAA; 32]);
+        assert_eq!(entries[0].name, "Peer1");
+    }
+
+    #[test]
+    fn test_parse_discover_response_multiple_entries() {
+        let mut data = Vec::new();
+        // Entry 1
+        data.extend_from_slice(&[0x11; 32]);
+        let mut name1 = [0u8; 32];
+        name1[..2].copy_from_slice(b"A1");
+        data.extend_from_slice(&name1);
+        // Entry 2
+        data.extend_from_slice(&[0x22; 32]);
+        let mut name2 = [0u8; 32];
+        name2[..2].copy_from_slice(b"B2");
+        data.extend_from_slice(&name2);
+        let entries = parse_discover_response(&data);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "A1");
+        assert_eq!(entries[1].name, "B2");
+    }
+
+    #[test]
+    fn test_parse_discover_response_too_short_entry_ignored() {
+        // Less than 38 bytes, so no entries parsed
+        let data = vec![0u8; 37];
+        let entries = parse_discover_response(&data);
+        assert!(entries.is_empty());
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -158,6 +158,91 @@ impl MessageReader {
             .retain(|_, req| req.expires_at > now);
     }
 
+    /// Dispatch a `PacketType::BinaryResponse` frame based on a pending
+    /// request (if any). Returns the appropriate [`MeshCoreEvent`].
+    fn dispatch_binary_response(
+        tag: [u8; 4],
+        data: Vec<u8>,
+        request: Option<BinaryRequest>,
+    ) -> MeshCoreEvent {
+        if let Some(req) = request {
+            match req.request_type {
+                BinaryReqType::Status => {
+                    if let Ok(status) = parse_status(&data, [0; 6]) {
+                        MeshCoreEvent::new(EventType::StatusResponse, EventPayload::Status(status))
+                    } else {
+                        MeshCoreEvent::new(
+                            EventType::BinaryResponse,
+                            EventPayload::BinaryResponse { tag, data },
+                        )
+                    }
+                }
+                BinaryReqType::Telemetry => {
+                    MeshCoreEvent::new(EventType::TelemetryResponse, EventPayload::Telemetry(data))
+                }
+                BinaryReqType::Mma => {
+                    let entries = parse_mma(&data);
+                    MeshCoreEvent::new(EventType::MmaResponse, EventPayload::Mma(entries))
+                }
+                BinaryReqType::Acl => {
+                    let entries = parse_acl(&data);
+                    MeshCoreEvent::new(EventType::AclResponse, EventPayload::Acl(entries))
+                }
+                BinaryReqType::Neighbours => {
+                    let pk_plen = req
+                        .context
+                        .get("pubkey_prefix_length")
+                        .and_then(|s| s.parse::<usize>().ok())
+                        .unwrap_or(4);
+                    if let Ok(neighbours) = parse_neighbours(&data, pk_plen) {
+                        MeshCoreEvent::new(
+                            EventType::NeighboursResponse,
+                            EventPayload::Neighbours(neighbours),
+                        )
+                    } else {
+                        MeshCoreEvent::new(
+                            EventType::BinaryResponse,
+                            EventPayload::BinaryResponse { tag, data },
+                        )
+                    }
+                }
+                BinaryReqType::KeepAlive => MeshCoreEvent::new(
+                    EventType::BinaryResponse,
+                    EventPayload::BinaryResponse { tag, data },
+                ),
+            }
+        } else {
+            MeshCoreEvent::new(
+                EventType::BinaryResponse,
+                EventPayload::BinaryResponse { tag, data },
+            )
+        }
+    }
+
+    /// Dispatch a `PacketType::ControlData` payload, returning the
+    /// appropriate [`MeshCoreEvent`].
+    fn dispatch_control_data(payload: &[u8]) -> Option<MeshCoreEvent> {
+        if payload.is_empty() {
+            return None;
+        }
+
+        let control_type = ControlType::from(payload[0]);
+        let event = match control_type {
+            ControlType::NodeDiscoverResp => {
+                let entries = parse_discover_response(&payload[1..]);
+                MeshCoreEvent::new(
+                    EventType::DiscoverResponse,
+                    EventPayload::DiscoverResponse(entries),
+                )
+            }
+            _ => MeshCoreEvent::new(
+                EventType::ControlData,
+                EventPayload::Bytes(payload.to_vec()),
+            ),
+        };
+        Some(event)
+    }
+
     /// Handle received data
     pub async fn handle_rx(&self, data: Vec<u8>) -> Result<()> {
         if data.is_empty() {
@@ -206,16 +291,10 @@ impl MessageReader {
             }
 
             PacketType::ContactEnd => {
-                // Get last_modification_timestamp if present
-                let last_modification_timestamp = if payload.len() >= 4 {
-                    read_u32_le(payload, 0).unwrap_or(0)
-                } else {
-                    0
-                };
+                let last_modification_timestamp = parse_contact_end_timestamp(payload);
                 *self.contacts_last_modification_timestamp.write().await =
                     last_modification_timestamp;
 
-                // Emit contacts event
                 let contacts = std::mem::take(&mut *self.pending_contacts.write().await);
                 let event =
                     MeshCoreEvent::new(EventType::Contacts, EventPayload::Contacts(contacts))
@@ -453,101 +532,17 @@ impl MessageReader {
 
             PacketType::BinaryResponse => {
                 if let Some(frame) = parse_binary_response_frame(payload) {
-                    let tag = frame.tag;
-                    let data = frame.data;
-                    let tag_hex = hex_encode(&tag);
-
-                    // Check if we have a pending request for this tag
+                    let tag_hex = hex_encode(&frame.tag);
                     let request = self.pending_requests.write().await.remove(&tag_hex);
-
-                    let event = if let Some(req) = request {
-                        match req.request_type {
-                            BinaryReqType::Status => {
-                                if let Ok(status) = parse_status(&data, [0; 6]) {
-                                    MeshCoreEvent::new(
-                                        EventType::StatusResponse,
-                                        EventPayload::Status(status),
-                                    )
-                                } else {
-                                    MeshCoreEvent::new(
-                                        EventType::BinaryResponse,
-                                        EventPayload::BinaryResponse { tag, data },
-                                    )
-                                }
-                            }
-                            BinaryReqType::Telemetry => MeshCoreEvent::new(
-                                EventType::TelemetryResponse,
-                                EventPayload::Telemetry(data),
-                            ),
-                            BinaryReqType::Mma => {
-                                let entries = parse_mma(&data);
-                                MeshCoreEvent::new(
-                                    EventType::MmaResponse,
-                                    EventPayload::Mma(entries),
-                                )
-                            }
-                            BinaryReqType::Acl => {
-                                let entries = parse_acl(&data);
-                                MeshCoreEvent::new(
-                                    EventType::AclResponse,
-                                    EventPayload::Acl(entries),
-                                )
-                            }
-                            BinaryReqType::Neighbours => {
-                                let pk_plen = req
-                                    .context
-                                    .get("pubkey_prefix_length")
-                                    .and_then(|s| s.parse::<usize>().ok())
-                                    .unwrap_or(4);
-                                if let Ok(neighbours) = parse_neighbours(&data, pk_plen) {
-                                    MeshCoreEvent::new(
-                                        EventType::NeighboursResponse,
-                                        EventPayload::Neighbours(neighbours),
-                                    )
-                                } else {
-                                    MeshCoreEvent::new(
-                                        EventType::BinaryResponse,
-                                        EventPayload::BinaryResponse { tag, data },
-                                    )
-                                }
-                            }
-                            BinaryReqType::KeepAlive => MeshCoreEvent::new(
-                                EventType::BinaryResponse,
-                                EventPayload::BinaryResponse { tag, data },
-                            ),
-                        }
-                    } else {
-                        MeshCoreEvent::new(
-                            EventType::BinaryResponse,
-                            EventPayload::BinaryResponse { tag, data },
-                        )
-                    }
-                    .with_attribute("tag", tag_hex);
-
+                    let event = Self::dispatch_binary_response(frame.tag, frame.data, request)
+                        .with_attribute("tag", tag_hex);
                     self.dispatcher.emit(event).await;
                 }
             }
 
             PacketType::ControlData => {
-                if !payload.is_empty() {
-                    let control_type = ControlType::from(payload[0]);
-                    match control_type {
-                        ControlType::NodeDiscoverResp => {
-                            let entries = parse_discover_response(&payload[1..]);
-                            let event = MeshCoreEvent::new(
-                                EventType::DiscoverResponse,
-                                EventPayload::DiscoverResponse(entries),
-                            );
-                            self.dispatcher.emit(event).await;
-                        }
-                        _ => {
-                            let event = MeshCoreEvent::new(
-                                EventType::ControlData,
-                                EventPayload::Bytes(payload.to_vec()),
-                            );
-                            self.dispatcher.emit(event).await;
-                        }
-                    }
+                if let Some(event) = Self::dispatch_control_data(payload) {
+                    self.dispatcher.emit(event).await;
                 }
             }
 
@@ -2438,5 +2433,80 @@ mod tests {
             }
             _ => panic!("Expected LogData payload"),
         }
+    }
+
+    // ========== dispatch_binary_response tests ==========
+
+    #[test]
+    fn test_dispatch_binary_response_no_pending() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![0xAA, 0xBB];
+        let event = MessageReader::dispatch_binary_response(tag, data.clone(), None);
+        assert_eq!(event.event_type, EventType::BinaryResponse);
+        match event.payload {
+            EventPayload::BinaryResponse { tag: t, data: d } => {
+                assert_eq!(t, tag);
+                assert_eq!(d, data);
+            }
+            _ => panic!("Expected BinaryResponse payload"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_telemetry() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![0x10, 0x20, 0x30];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Telemetry,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::TelemetryResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_keepalive() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::KeepAlive,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::BinaryResponse);
+    }
+
+    // ========== dispatch_control_data tests ==========
+
+    #[test]
+    fn test_dispatch_control_data_empty() {
+        assert!(MessageReader::dispatch_control_data(&[]).is_none());
+    }
+
+    #[test]
+    fn test_dispatch_control_data_discover_resp() {
+        let mut data = vec![ControlType::NodeDiscoverResp as u8];
+        // Add one entry: 32-byte pubkey + 32-byte name
+        data.extend_from_slice(&[0xAA; 32]);
+        let mut name = [0u8; 32];
+        name[..4].copy_from_slice(b"Test");
+        data.extend_from_slice(&name);
+
+        let event = MessageReader::dispatch_control_data(&data).unwrap();
+        assert_eq!(event.event_type, EventType::DiscoverResponse);
+    }
+
+    #[test]
+    fn test_dispatch_control_data_other() {
+        // Unknown control type should emit ControlData
+        let data = vec![0xFF, 0x01, 0x02];
+        let event = MessageReader::dispatch_control_data(&data).unwrap();
+        assert_eq!(event.event_type, EventType::ControlData);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2509,4 +2509,105 @@ mod tests {
         let event = MessageReader::dispatch_control_data(&data).unwrap();
         assert_eq!(event.event_type, EventType::ControlData);
     }
+
+    #[test]
+    fn test_dispatch_binary_response_status_ok() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        // Build valid status data (52 bytes minimum)
+        let data = vec![0u8; 52];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Status,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::StatusResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_status_parse_fail() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        // Too-short data for parse_status
+        let data = vec![0x01];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Status,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        // Falls back to generic BinaryResponse
+        assert_eq!(event.event_type, EventType::BinaryResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_mma() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Mma,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::MmaResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_acl() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![];
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Acl,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::AclResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_neighbours_ok() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        // Build valid neighbours data: count(1) + at least one entry
+        let mut data = vec![1u8]; // count = 1
+        data.extend_from_slice(&[0xAA; 4]); // pubkey prefix (4 bytes)
+        data.push(40); // snr
+        data.push((-70i8) as u8); // rssi
+        data.extend_from_slice(&1000u32.to_le_bytes()); // last_seen
+        let mut context = HashMap::new();
+        context.insert("pubkey_prefix_length".to_string(), "4".to_string());
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Neighbours,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context,
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        assert_eq!(event.event_type, EventType::NeighboursResponse);
+    }
+
+    #[test]
+    fn test_dispatch_binary_response_neighbours_parse_fail() {
+        let tag = [0x01, 0x02, 0x03, 0x04];
+        let data = vec![]; // too short for neighbours
+        let req = BinaryRequest {
+            request_type: BinaryReqType::Neighbours,
+            pubkey_prefix: vec![],
+            expires_at: Instant::now() + Duration::from_secs(60),
+            context: HashMap::new(),
+            is_anon: false,
+        };
+        let event = MessageReader::dispatch_binary_response(tag, data, Some(req));
+        // Falls back to generic BinaryResponse
+        assert_eq!(event.event_type, EventType::BinaryResponse);
+    }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,7 +8,7 @@ use tokio::sync::RwLock;
 use crate::events::*;
 use crate::packets::{BinaryReqType, ControlType, PacketType, PayloadType};
 use crate::parsing::*;
-use crate::{Result, CHANNEL_INFO_LEN, CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
+use crate::Result;
 
 /// Tracks a pending binary request
 #[derive(Debug, Clone)]
@@ -241,25 +241,8 @@ impl MessageReader {
             }
 
             PacketType::Battery => {
-                if payload.len() >= 2 {
-                    let battery_mv = read_u16_le(payload, 0).unwrap_or(0);
-                    // Storage info is optional and uses u32 fields
-                    let (used_kb, total_kb) = if payload.len() >= 10 {
-                        (
-                            Some(read_u32_le(payload, 2).unwrap_or(0)),
-                            Some(read_u32_le(payload, 6).unwrap_or(0)),
-                        )
-                    } else {
-                        (None, None)
-                    };
-                    let event = MeshCoreEvent::new(
-                        EventType::Battery,
-                        EventPayload::Battery(BatteryInfo {
-                            battery_mv,
-                            used_kb,
-                            total_kb,
-                        }),
-                    );
+                if let Some(info) = parse_battery(payload) {
+                    let event = MeshCoreEvent::new(EventType::Battery, EventPayload::Battery(info));
                     self.dispatcher.emit(event).await;
                 }
             }
@@ -274,20 +257,10 @@ impl MessageReader {
             }
 
             PacketType::MsgSent => {
-                if payload.len() >= 9 {
-                    let message_type = payload[0];
-                    let expected_ack: [u8; 4] = read_bytes(payload, 1).unwrap_or([0; 4]);
-                    let suggested_timeout = read_u32_le(payload, 5).unwrap_or(5000);
-
-                    let event = MeshCoreEvent::new(
-                        EventType::MsgSent,
-                        EventPayload::MsgSent(MsgSentInfo {
-                            message_type,
-                            expected_ack,
-                            suggested_timeout,
-                        }),
-                    )
-                    .with_attribute("tag", hex_encode(&expected_ack));
+                if let Some(info) = parse_msg_sent(payload) {
+                    let tag_hex = hex_encode(&info.expected_ack);
+                    let event = MeshCoreEvent::new(EventType::MsgSent, EventPayload::MsgSent(info))
+                        .with_attribute("tag", tag_hex);
                     self.dispatcher.emit(event).await;
                 }
             }
@@ -359,22 +332,9 @@ impl MessageReader {
             }
 
             PacketType::ChannelInfo => {
-                // Firmware always sends CHANNEL_INFO_LEN bytes: 1 (idx) + name + secret
-                if payload.len() >= CHANNEL_INFO_LEN {
-                    let channel_idx = payload[0];
-                    let name = read_string(payload, 1, CHANNEL_NAME_LEN);
-                    let secret: [u8; CHANNEL_SECRET_LEN] =
-                        read_bytes(payload, 1 + CHANNEL_NAME_LEN)
-                            .unwrap_or([0; CHANNEL_SECRET_LEN]);
-
-                    let event = MeshCoreEvent::new(
-                        EventType::ChannelInfo,
-                        EventPayload::ChannelInfo(ChannelInfoData {
-                            channel_idx,
-                            name,
-                            secret,
-                        }),
-                    );
+                if let Some(info) = parse_channel_info(payload) {
+                    let event =
+                        MeshCoreEvent::new(EventType::ChannelInfo, EventPayload::ChannelInfo(info));
                     self.dispatcher.emit(event).await;
                 }
             }
@@ -413,26 +373,13 @@ impl MessageReader {
             }
 
             PacketType::Stats => {
-                // Stats have a category byte followed by data
-                if !payload.is_empty() {
-                    let category = match payload[0] {
-                        0 => StatsCategory::Core,
-                        1 => StatsCategory::Radio,
-                        2 => StatsCategory::Packets,
-                        _ => StatsCategory::Core,
-                    };
-                    let event_type = match category {
+                if let Some(stats) = parse_stats(payload) {
+                    let event_type = match stats.category {
                         StatsCategory::Core => EventType::StatsCore,
                         StatsCategory::Radio => EventType::StatsRadio,
                         StatsCategory::Packets => EventType::StatsPackets,
                     };
-                    let event = MeshCoreEvent::new(
-                        event_type,
-                        EventPayload::Stats(StatsData {
-                            category,
-                            raw: payload[1..].to_vec(),
-                        }),
-                    );
+                    let event = MeshCoreEvent::new(event_type, EventPayload::Stats(stats));
                     self.dispatcher.emit(event).await;
                 }
             }
@@ -447,51 +394,19 @@ impl MessageReader {
             }
 
             PacketType::Advertisement => {
-                if payload.len() >= 14 {
-                    let prefix: [u8; 6] = read_bytes(payload, 0).unwrap_or([0; 6]);
-                    let name = read_string(payload, 6, 32);
-                    let lat = if payload.len() >= 42 {
-                        read_i32_le(payload, 38).unwrap_or(0)
-                    } else {
-                        0
-                    };
-                    let lon = if payload.len() >= 46 {
-                        read_i32_le(payload, 42).unwrap_or(0)
-                    } else {
-                        0
-                    };
-
+                if let Some(advert) = parse_advertisement(payload) {
                     let event = MeshCoreEvent::new(
                         EventType::Advertisement,
-                        EventPayload::Advertisement(AdvertisementData {
-                            prefix,
-                            name,
-                            lat,
-                            lon,
-                        }),
+                        EventPayload::Advertisement(advert),
                     );
                     self.dispatcher.emit(event).await;
                 }
             }
 
             PacketType::PathUpdate => {
-                if payload.len() >= 7 {
-                    let prefix: [u8; 6] = read_bytes(payload, 0).unwrap_or([0; 6]);
-                    let path_len = payload[6] as i8;
-                    let path = if payload.len() > 7 {
-                        payload[7..].to_vec()
-                    } else {
-                        Vec::new()
-                    };
-
-                    let event = MeshCoreEvent::new(
-                        EventType::PathUpdate,
-                        EventPayload::PathUpdate(PathUpdateData {
-                            prefix,
-                            path_len,
-                            path,
-                        }),
-                    );
+                if let Some(update) = parse_path_update(payload) {
+                    let event =
+                        MeshCoreEvent::new(EventType::PathUpdate, EventPayload::PathUpdate(update));
                     self.dispatcher.emit(event).await;
                 }
             }
@@ -640,15 +555,7 @@ impl MessageReader {
                     let control_type = ControlType::from(payload[0]);
                     match control_type {
                         ControlType::NodeDiscoverResp => {
-                            // Parse discover response
-                            let mut entries = Vec::new();
-                            let mut offset = 1;
-                            while offset + 38 <= payload.len() {
-                                let pubkey = payload[offset..offset + 32].to_vec();
-                                let name = read_string(payload, offset + 32, 32);
-                                entries.push(DiscoverEntry { pubkey, name });
-                                offset += 64;
-                            }
+                            let entries = parse_discover_response(&payload[1..]);
                             let event = MeshCoreEvent::new(
                                 EventType::DiscoverResponse,
                                 EventPayload::DiscoverResponse(entries),
@@ -667,20 +574,9 @@ impl MessageReader {
             }
 
             PacketType::TraceData => {
-                // Parse trace hops
-                let mut hops = Vec::new();
-                let mut offset = 0;
-                while offset + 7 <= payload.len() {
-                    let prefix: [u8; 6] = read_bytes(payload, offset).unwrap_or([0; 6]);
-                    let snr_raw = payload[offset + 6] as i8;
-                    let snr = snr_raw as f32 / 4.0;
-                    hops.push(TraceHop { prefix, snr });
-                    offset += 7;
-                }
-                let event = MeshCoreEvent::new(
-                    EventType::TraceData,
-                    EventPayload::TraceData(TraceInfo { hops }),
-                );
+                let trace = parse_trace_data(payload);
+                let event =
+                    MeshCoreEvent::new(EventType::TraceData, EventPayload::TraceData(trace));
                 self.dispatcher.emit(event).await;
             }
 
@@ -734,6 +630,7 @@ impl MessageReader {
 mod tests {
     use super::*;
     use crate::packets::RouteType;
+    use crate::{CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
     use std::time::Duration;
 
     fn create_reader() -> (MessageReader, Arc<EventDispatcher>) {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -359,14 +359,7 @@ impl MessageReader {
             }
 
             PacketType::CustomVars => {
-                // Parse key-value pairs
-                let mut vars = HashMap::new();
-                let text = String::from_utf8_lossy(payload);
-                for line in text.lines() {
-                    if let Some((key, value)) = line.split_once('=') {
-                        vars.insert(key.to_string(), value.to_string());
-                    }
-                }
+                let vars = parse_custom_vars(payload);
                 let event =
                     MeshCoreEvent::new(EventType::CustomVars, EventPayload::CustomVars(vars));
                 self.dispatcher.emit(event).await;
@@ -436,51 +429,39 @@ impl MessageReader {
             }
 
             PacketType::StatusResponse => {
-                if payload.len() >= 58 {
-                    // The first 6 bytes are the sender prefix
-                    let sender_prefix: [u8; 6] = read_bytes(payload, 0).unwrap_or([0; 6]);
-                    if let Ok(status) = parse_status(&payload[6..], sender_prefix) {
-                        let tag_hex = hex_encode(&sender_prefix);
-                        let event = MeshCoreEvent::new(
-                            EventType::StatusResponse,
-                            EventPayload::Status(status),
-                        )
-                        .with_attribute("prefix", tag_hex);
-                        self.dispatcher.emit(event).await;
-                    }
+                if let Some(frame) = parse_status_response(payload) {
+                    let prefix_hex = hex_encode(&frame.sender_prefix);
+                    let event = MeshCoreEvent::new(
+                        EventType::StatusResponse,
+                        EventPayload::Status(frame.status),
+                    )
+                    .with_attribute("prefix", prefix_hex);
+                    self.dispatcher.emit(event).await;
                 }
             }
 
             PacketType::TelemetryResponse => {
-                // The first bytes are tag, the rest is LPP data
-                if payload.len() >= 4 {
-                    let tag: [u8; 4] = read_bytes(payload, 0).unwrap_or([0; 4]);
-                    let telemetry = payload[4..].to_vec();
+                if let Some(frame) = parse_telemetry_response(payload) {
                     let event = MeshCoreEvent::new(
                         EventType::TelemetryResponse,
-                        EventPayload::Telemetry(telemetry),
+                        EventPayload::Telemetry(frame.data),
                     )
-                    .with_attribute("tag", hex_encode(&tag));
+                    .with_attribute("tag", hex_encode(&frame.tag));
                     self.dispatcher.emit(event).await;
                 }
             }
 
             PacketType::BinaryResponse => {
-                // Firmware layout: [subtype: 1][tag: 4][data...]
-                // Skip the subtype byte; tag lives at offset 1, data from offset 5.
-                // See meshcore_py reader.py:727:
-                //   dbuf.read(1); tag = dbuf.read(4).hex(); response_data = dbuf.read()
-                if payload.len() >= 5 {
-                    let tag: [u8; 4] = read_bytes(payload, 1).unwrap_or([0; 4]);
-                    let data = payload[5..].to_vec();
+                if let Some(frame) = parse_binary_response_frame(payload) {
+                    let tag = frame.tag;
+                    let data = frame.data;
+                    let tag_hex = hex_encode(&tag);
 
                     // Check if we have a pending request for this tag
-                    let tag_hex = hex_encode(&tag);
                     let request = self.pending_requests.write().await.remove(&tag_hex);
 
-                    if let Some(req) = request {
-                        // Emit typed event based on the request type
-                        let event = match req.request_type {
+                    let event = if let Some(req) = request {
+                        match req.request_type {
                             BinaryReqType::Status => {
                                 if let Ok(status) = parse_status(&data, [0; 6]) {
                                     MeshCoreEvent::new(
@@ -535,18 +516,15 @@ impl MessageReader {
                                 EventPayload::BinaryResponse { tag, data },
                             ),
                         }
-                        .with_attribute("tag", tag_hex);
-
-                        self.dispatcher.emit(event).await;
                     } else {
-                        // No matching request, emit generic binary response
-                        let event = MeshCoreEvent::new(
+                        MeshCoreEvent::new(
                             EventType::BinaryResponse,
                             EventPayload::BinaryResponse { tag, data },
                         )
-                        .with_attribute("tag", tag_hex);
-                        self.dispatcher.emit(event).await;
                     }
+                    .with_attribute("tag", tag_hex);
+
+                    self.dispatcher.emit(event).await;
                 }
             }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -685,42 +685,13 @@ impl MessageReader {
             }
 
             PacketType::AdvertResponse => {
-                if payload.len() >= 42 {
-                    let tag: [u8; 4] = read_bytes(payload, 0).unwrap_or([0; 4]);
-                    let pubkey: [u8; 32] = read_bytes(payload, 4).unwrap_or([0; 32]);
-                    let adv_type = payload[36];
-                    let node_name = read_string(payload, 37, 32);
-                    let timestamp = read_u32_le(payload, 69).unwrap_or(0);
-                    let flags = if payload.len() > 73 { payload[73] } else { 0 };
-
-                    let (lat, lon, node_desc) = if payload.len() >= 82 {
-                        let lat = Some(read_i32_le(payload, 74).unwrap_or(0));
-                        let lon = Some(read_i32_le(payload, 78).unwrap_or(0));
-                        let desc = if payload.len() > 82 {
-                            Some(read_string(payload, 82, 32))
-                        } else {
-                            None
-                        };
-                        (lat, lon, desc)
-                    } else {
-                        (None, None, None)
-                    };
-
+                if let Some(resp) = parse_advert_response(payload) {
+                    let tag_hex = hex_encode(&resp.tag);
                     let event = MeshCoreEvent::new(
                         EventType::AdvertResponse,
-                        EventPayload::AdvertResponse(AdvertResponseData {
-                            tag,
-                            pubkey,
-                            adv_type,
-                            node_name,
-                            timestamp,
-                            flags,
-                            lat,
-                            lon,
-                            node_desc,
-                        }),
+                        EventPayload::AdvertResponse(resp),
                     )
-                    .with_attribute("tag", hex_encode(&tag));
+                    .with_attribute("tag", tag_hex);
                     self.dispatcher.emit(event).await;
                 }
             }


### PR DESCRIPTION
Extract the inline `PacketType::AdvertResponse` processing from `reader.rs` into a new `parse_advert_response()` function in `parsing.rs`, following the same pattern used by `parse_raw_advertisement`, `parse_contact`, etc.

### Changes

**`src/parsing.rs`**:
- Define named constants for all wire-format offsets and sizes, replacing magic numbers (0, 4, 36, 37, 69, 73, 74, 78, 82)
- Add `parse_advert_response()` function that returns `Option<AdvertResponseData>`
- Fix the minimum length check from 42 (too permissive) to 74 (the actual minimum: tag + pubkey + adv_type + name + timestamp + flags)
- Add 8 unit tests covering: too short, empty, minimal, with lat/lon, with description, partial lat/lon, exact boundary, and offset constant verification

**`src/reader.rs`**:
- Replace 30+ lines of inline parsing with a single `parse_advert_response()` call

Fixes #60