### PR TITLE
Document command-only packet types in handle_rx

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -546,11 +546,15 @@ impl MessageReader {
                 self.dispatcher.emit(event).await;
             }
 
-            PacketType::BinaryReq => {}
-            PacketType::FactoryReset => {}
-            PacketType::PathDiscovery => {}
-            PacketType::SetFloodScope => {}
-            PacketType::SendControlData => {}
+            // Command codes (app -> radio direction only). The radio responds
+            // with different packet types (Ok, BinaryResponse, etc.), never
+            // by echoing these codes back. They exist in PacketType because
+            // the same byte values serve as command identifiers on the wire.
+            PacketType::BinaryReq
+            | PacketType::FactoryReset
+            | PacketType::PathDiscovery
+            | PacketType::SetFloodScope
+            | PacketType::SendControlData => {}
 
             PacketType::RawData => {
                 let raw_data = parse_raw_data(payload)?;
@@ -564,6 +568,7 @@ impl MessageReader {
                 self.dispatcher.emit(event).await;
             }
 
+            // TODO: parse path discovery response (#74)
             PacketType::PathDiscoveryResponse => {}
             _ => {
                 tracing::debug!("Unknown packet type: {:?}", packet_type);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2593,4 +2593,29 @@ mod tests {
         // Falls back to generic BinaryResponse
         assert_eq!(event.event_type, EventType::BinaryResponse);
     }
+
+    #[tokio::test]
+    async fn test_handle_rx_command_only_packet_types_ignored() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // These are outbound command codes that should be silently ignored
+        // when received as inbound packets.
+        for packet_type_byte in [
+            PacketType::BinaryReq as u8,
+            PacketType::FactoryReset as u8,
+            PacketType::PathDiscovery as u8,
+            PacketType::SetFloodScope as u8,
+            PacketType::SendControlData as u8,
+        ] {
+            reader.handle_rx(vec![packet_type_byte]).await.unwrap();
+        }
+
+        // None of them should emit any event
+        let result = tokio::time::timeout(Duration::from_millis(50), receiver.recv()).await;
+        assert!(
+            result.is_err(),
+            "Command-only packet types should not emit events"
+        );
+    }
 }


### PR DESCRIPTION
Combine the 5 empty match arms for `BinaryReq`, `FactoryReset`, `PathDiscovery`, `SetFloodScope` and `SendControlData` into a single grouped arm with a comment explaining why they are no-ops: these are outbound command codes (app -> radio direction) that the radio never echoes back as inbound packet types. The radio responds with different codes (`Ok`, `BinaryResponse`, etc.).

Also adds a TODO comment on the `PathDiscoveryResponse` empty arm referencing #74.

### Related issues created

The missing functionality identified in #71 has been broken into separate issues:

- #74: Parse `PathDiscoveryResponse` packets (inbound response type that needs a parser)
- #75: Add `send_path_discovery()` command (outbound command, depends on #74)
- #76: Add `send_factory_reset()` command (fire-and-forget like `reboot()`)
- #77: Add `send_control_data()` command (outbound command)

Fixes #71