### PR TITLE
Add send_path_discovery() command

### DIFF
--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -61,6 +61,7 @@ const CMD_SIGN_FINISH: u8 = 35;
 const CMD_GET_CUSTOM_VARS: u8 = 40;
 const CMD_SET_CUSTOM_VAR: u8 = 41;
 const CMD_SEND_BINARY_REQ: u8 = 50;
+const CMD_PATH_DISCOVERY: u8 = 52;
 const CMD_SET_FLOOD_SCOPE: u8 = 54;
 
 /// Destination type for commands
@@ -486,6 +487,59 @@ impl CommandHandler {
         }
         self.send(&data, Some(EventType::Ok)).await?;
         Ok(())
+    }
+
+    /// Send a path discovery request to a destination node.
+    ///
+    /// Sends the command and waits for a `PathDiscoveryResponse` event
+    /// containing the outbound and inbound paths to the destination.
+    ///
+    /// Format: [CMD_PATH_DISCOVERY=0x34][0x00][pubkey: 32]
+    pub async fn send_path_discovery(
+        &self,
+        dest: impl Into<Destination>,
+    ) -> Result<PathDiscoveryResponseData> {
+        self.send_path_discovery_with_timeout(dest, self.default_timeout)
+            .await
+    }
+
+    /// Send a path discovery request with a custom timeout.
+    pub async fn send_path_discovery_with_timeout(
+        &self,
+        dest: impl Into<Destination>,
+        timeout: Duration,
+    ) -> Result<PathDiscoveryResponseData> {
+        let dest: Destination = dest.into();
+        let pubkey = dest.public_key().ok_or_else(|| {
+            Error::invalid_param("Path discovery requires a full 32-byte public key")
+        })?;
+
+        let mut data = vec![CMD_PATH_DISCOVERY, 0x00];
+        data.extend_from_slice(&pubkey);
+
+        // First wait for MsgSent confirmation
+        let sent = self
+            .send_with_timeout(&data, Some(EventType::MsgSent), timeout)
+            .await?;
+
+        // Then wait for the PathDiscoveryResponse
+        let filters = match sent.payload {
+            EventPayload::MsgSent(ref info) => {
+                let mut f = HashMap::new();
+                f.insert("tag".to_string(), hex_encode(&info.expected_ack));
+                f
+            }
+            _ => HashMap::new(),
+        };
+
+        let event = self
+            .wait_for_event(Some(EventType::PathDiscoveryResponse), filters, timeout)
+            .await?;
+
+        match event.payload {
+            EventPayload::PathDiscoveryResponse(resp) => Ok(resp),
+            _ => Err(Error::protocol("Unexpected response to path discovery")),
+        }
     }
 
     /// Export private key
@@ -1281,6 +1335,7 @@ mod tests {
         assert_eq!(CMD_GET_CUSTOM_VARS, 40);
         assert_eq!(CMD_SET_CUSTOM_VAR, 41);
         assert_eq!(CMD_SEND_BINARY_REQ, 50);
+        assert_eq!(CMD_PATH_DISCOVERY, 52);
     }
 
     // ========== CommandHandler Tests with Mock Infrastructure ==========
@@ -2114,5 +2169,24 @@ mod tests {
             .request_neighbours_with_timeout(dest, 10, 0, 0, 33, Duration::from_millis(100))
             .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_path_discovery_wire_format() {
+        let (handler, mut rx, _dispatcher) = create_test_handler();
+
+        let dest = vec![0xAAu8; 32];
+        // The command will timeout since no response comes, but we can
+        // check the wire format of what was sent.
+        let _result = handler
+            .send_path_discovery_with_timeout(dest, Duration::from_millis(50))
+            .await;
+
+        // Verify the sent data format
+        let sent = rx.recv().await.unwrap();
+        assert_eq!(sent[0], CMD_PATH_DISCOVERY); // command byte
+        assert_eq!(sent[1], 0x00); // reserved byte
+        assert_eq!(&sent[2..34], &[0xAA; 32]); // 32-byte public key
+        assert_eq!(sent.len(), 34); // total: 1 + 1 + 32
     }
 }

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -518,22 +518,16 @@ impl CommandHandler {
         data.extend_from_slice(&pubkey);
 
         // First wait for MsgSent confirmation
-        let sent = self
-            .send_with_timeout(&data, Some(EventType::MsgSent), timeout)
+        self.send_with_timeout(&data, Some(EventType::MsgSent), timeout)
             .await?;
 
         // Then wait for the PathDiscoveryResponse
-        let filters = match sent.payload {
-            EventPayload::MsgSent(ref info) => {
-                let mut f = HashMap::new();
-                f.insert("tag".to_string(), hex_encode(&info.expected_ack));
-                f
-            }
-            _ => HashMap::new(),
-        };
-
         let event = self
-            .wait_for_event(Some(EventType::PathDiscoveryResponse), filters, timeout)
+            .wait_for_event(
+                Some(EventType::PathDiscoveryResponse),
+                HashMap::new(),
+                timeout,
+            )
             .await?;
 
         match event.payload {
@@ -2188,5 +2182,73 @@ mod tests {
         assert_eq!(sent[1], 0x00); // reserved byte
         assert_eq!(&sent[2..34], &[0xAA; 32]); // 32-byte public key
         assert_eq!(sent.len(), 34); // total: 1 + 1 + 32
+    }
+
+    #[tokio::test]
+    async fn test_send_path_discovery_success() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            // Consume the sent command
+            let _sent = rx.recv().await.unwrap();
+
+            // Emit MsgSent response
+            dispatcher_clone
+                .emit(
+                    MeshCoreEvent::new(
+                        EventType::MsgSent,
+                        EventPayload::MsgSent(MsgSentInfo {
+                            message_type: 0,
+                            expected_ack: [0x01, 0x02, 0x03, 0x04],
+                            suggested_timeout: 5000,
+                        }),
+                    )
+                    .with_attribute("tag", "01020304".to_string()),
+                )
+                .await;
+
+            // Small delay then emit PathDiscoveryResponse
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            dispatcher_clone
+                .emit(
+                    MeshCoreEvent::new(
+                        EventType::PathDiscoveryResponse,
+                        EventPayload::PathDiscoveryResponse(PathDiscoveryResponseData {
+                            pubkey_prefix: [0xAA; 6],
+                            out_path_len: 1,
+                            out_path_hash_len: 1,
+                            out_path: vec![0x11],
+                            in_path_len: 0,
+                            in_path_hash_len: 1,
+                            in_path: vec![],
+                        }),
+                    )
+                    .with_attribute("prefix", "aaaaaaaaaaaa".to_string()),
+                )
+                .await;
+        });
+
+        let dest = vec![0xAAu8; 32];
+        let result = handler
+            .send_path_discovery_with_timeout(dest, Duration::from_millis(500))
+            .await;
+        assert!(result.is_ok());
+        let resp = result.unwrap();
+        assert_eq!(resp.pubkey_prefix, [0xAA; 6]);
+        assert_eq!(resp.out_path_len, 1);
+        assert_eq!(resp.out_path, vec![0x11]);
+    }
+
+    #[tokio::test]
+    async fn test_send_path_discovery_requires_full_key() {
+        let (handler, _rx, _dispatcher) = create_test_handler();
+
+        // 6-byte prefix should fail -- path discovery needs full 32-byte key
+        let dest: &[u8] = &[0xAA; 6];
+        let result = handler
+            .send_path_discovery_with_timeout(dest, Duration::from_millis(50))
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -142,6 +142,8 @@ pub enum EventPayload {
     BinaryResponse { tag: [u8; 4], data: Vec<u8> },
     /// Discover response
     DiscoverResponse(Vec<DiscoverEntry>),
+    /// Path discovery response
+    PathDiscoveryResponse(PathDiscoveryResponseData),
     /// Advert response
     AdvertResponse(AdvertResponseData),
     /// Stats data
@@ -516,6 +518,25 @@ pub struct DiscoverEntry {
     pub pubkey: Vec<u8>,
     /// Node name
     pub name: String,
+}
+
+/// Path discovery response data
+#[derive(Debug, Clone)]
+pub struct PathDiscoveryResponseData {
+    /// 6-byte public key prefix of the responding node
+    pub pubkey_prefix: [u8; 6],
+    /// Outbound path length (number of hops)
+    pub out_path_len: u8,
+    /// Outbound path hash size (bytes per hop hash, 1-4)
+    pub out_path_hash_len: u8,
+    /// Outbound path hashes
+    pub out_path: Vec<u8>,
+    /// Inbound path length (number of hops)
+    pub in_path_len: u8,
+    /// Inbound path hash size (bytes per hop hash, 1-4)
+    pub in_path_hash_len: u8,
+    /// Inbound path hashes
+    pub in_path: Vec<u8>,
 }
 
 /// Advertisement response data

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -6,8 +6,8 @@ use crate::error::Error;
 use crate::events::{
     AclEntry, AdvertResponseData, AdvertisementData, BatteryInfo, ChannelInfoData, ChannelMessage,
     Contact, ContactMessage, DeviceInfoData, DiscoverEntry, MeshPacketHeader, MmaEntry,
-    MsgSentInfo, Neighbour, NeighboursData, PathUpdateData, RawAdvertisement, SelfInfo,
-    StatsCategory, StatsData, StatusData, TraceHop, TraceInfo,
+    MsgSentInfo, Neighbour, NeighboursData, PathDiscoveryResponseData, PathUpdateData,
+    RawAdvertisement, SelfInfo, StatsCategory, StatsData, StatusData, TraceHop, TraceInfo,
 };
 use crate::packets::{PayloadType, RouteType};
 use crate::{Result, CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
@@ -1325,6 +1325,81 @@ pub fn parse_binary_response_frame(payload: &[u8]) -> Result<BinaryResponseFrame
     let data = payload[BINARY_RESP_DATA_OFFSET..].to_vec();
 
     Ok(BinaryResponseFrame { tag, data })
+}
+
+// --- PathDiscoveryResponse payload layout ---
+//
+// Firmware layout: [reserved: 1][pubkey_prefix: 6][out_path_byte: 1][out_path...][in_path_byte: 1][in_path...]
+// The path byte encodes hash_len in bits 6-7 and hop count in bits 0-5.
+
+/// Length of the reserved byte at the start of the response.
+const PATH_DISC_RESERVED_LEN: usize = 1;
+/// Length of the public key prefix.
+const PATH_DISC_PREFIX_LEN: usize = 6;
+/// Minimum payload length: reserved + prefix + out_path_byte + in_path_byte.
+const PATH_DISC_MIN_LEN: usize = PATH_DISC_RESERVED_LEN + PATH_DISC_PREFIX_LEN + 1 + 1;
+/// Offset of the public key prefix.
+const PATH_DISC_PREFIX_OFFSET: usize = PATH_DISC_RESERVED_LEN;
+/// Offset of the outbound path descriptor byte.
+const PATH_DISC_OUT_PATH_OFFSET: usize = PATH_DISC_PREFIX_OFFSET + PATH_DISC_PREFIX_LEN;
+
+/// Parse a [`PathDiscoveryResponseData`] from a
+/// `PacketType::PathDiscoveryResponse` payload.
+///
+/// Returns an error if the payload is too short.
+pub fn parse_path_discovery_response(payload: &[u8]) -> Result<PathDiscoveryResponseData> {
+    if payload.len() < PATH_DISC_MIN_LEN {
+        return Err(Error::protocol("PathDiscoveryResponse payload too short"));
+    }
+
+    let pubkey_prefix: [u8; 6] = read_bytes(payload, PATH_DISC_PREFIX_OFFSET)?;
+
+    // Outbound path
+    let out_path_byte = payload[PATH_DISC_OUT_PATH_OFFSET]; // jonesy:allow(bounds) -- checked >= PATH_DISC_MIN_LEN
+    let out_path_hash_len = ((out_path_byte & 0xC0) >> 6) + 1; // jonesy:allow(overflow)
+    let out_path_len = out_path_byte & 0x3F;
+    let out_path_bytes = out_path_len as usize * out_path_hash_len as usize; // jonesy:allow(overflow)
+
+    let out_path_start = PATH_DISC_OUT_PATH_OFFSET + 1; // jonesy:allow(overflow)
+    let out_path_end = out_path_start
+        .checked_add(out_path_bytes)
+        .ok_or_else(|| Error::protocol("PathDiscoveryResponse outbound path overflow"))?;
+    if out_path_end >= payload.len() {
+        return Err(Error::protocol(
+            "PathDiscoveryResponse outbound path truncated",
+        ));
+    }
+    let out_path = payload[out_path_start..out_path_end].to_vec(); // jonesy:allow(bounds) -- checked above
+
+    // Inbound path
+    let in_path_byte_offset = out_path_end;
+    let in_path_byte = *payload
+        .get(in_path_byte_offset)
+        .ok_or_else(|| Error::protocol("PathDiscoveryResponse missing inbound path byte"))?;
+    let in_path_hash_len = ((in_path_byte & 0xC0) >> 6) + 1; // jonesy:allow(overflow)
+    let in_path_len = in_path_byte & 0x3F;
+    let in_path_bytes = in_path_len as usize * in_path_hash_len as usize; // jonesy:allow(overflow)
+
+    let in_path_start = in_path_byte_offset + 1; // jonesy:allow(overflow)
+    let in_path_end = in_path_start
+        .checked_add(in_path_bytes)
+        .ok_or_else(|| Error::protocol("PathDiscoveryResponse inbound path overflow"))?;
+    if in_path_end > payload.len() {
+        return Err(Error::protocol(
+            "PathDiscoveryResponse inbound path truncated",
+        ));
+    }
+    let in_path = payload[in_path_start..in_path_end].to_vec(); // jonesy:allow(bounds) -- checked above
+
+    Ok(PathDiscoveryResponseData {
+        pubkey_prefix,
+        out_path_len,
+        out_path_hash_len,
+        out_path,
+        in_path_len,
+        in_path_hash_len,
+        in_path,
+    })
 }
 
 #[cfg(test)]
@@ -2702,5 +2777,73 @@ mod tests {
     fn test_parse_ack_valid() {
         let data = [0x11, 0x22, 0x33, 0x44];
         assert_eq!(parse_ack(&data).unwrap(), [0x11, 0x22, 0x33, 0x44]);
+    }
+
+    // ========== parse_path_discovery_response tests ==========
+
+    #[test]
+    fn test_parse_path_discovery_response_too_short() {
+        assert!(parse_path_discovery_response(&[]).is_err());
+        assert!(parse_path_discovery_response(&[0; 7]).is_err()); // need at least 9
+    }
+
+    #[test]
+    fn test_parse_path_discovery_response_no_paths() {
+        let mut data = vec![0x00]; // reserved
+        data.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66]); // pubkey prefix
+        data.push(0x00); // out_path: hash_len=1, path_len=0
+        data.push(0x00); // in_path: hash_len=1, path_len=0
+
+        let resp = parse_path_discovery_response(&data).unwrap();
+        assert_eq!(resp.pubkey_prefix, [0x11, 0x22, 0x33, 0x44, 0x55, 0x66]);
+        assert_eq!(resp.out_path_len, 0);
+        assert_eq!(resp.out_path_hash_len, 1);
+        assert!(resp.out_path.is_empty());
+        assert_eq!(resp.in_path_len, 0);
+        assert_eq!(resp.in_path_hash_len, 1);
+        assert!(resp.in_path.is_empty());
+    }
+
+    #[test]
+    fn test_parse_path_discovery_response_with_paths() {
+        let mut data = vec![0x00]; // reserved
+        data.extend_from_slice(&[0xAA; 6]); // pubkey prefix
+                                            // out_path: hash_len=2 (bits 6-7 = 0b01 -> +1 = 2), path_len=2
+        data.push(0b01_000010);
+        data.extend_from_slice(&[0x01, 0x02, 0x03, 0x04]); // 2 hops * 2 bytes = 4
+                                                           // in_path: hash_len=1 (bits 6-7 = 0b00 -> +1 = 1), path_len=3
+        data.push(0b00_000011);
+        data.extend_from_slice(&[0xA1, 0xA2, 0xA3]); // 3 hops * 1 byte = 3
+
+        let resp = parse_path_discovery_response(&data).unwrap();
+        assert_eq!(resp.out_path_len, 2);
+        assert_eq!(resp.out_path_hash_len, 2);
+        assert_eq!(resp.out_path, vec![0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(resp.in_path_len, 3);
+        assert_eq!(resp.in_path_hash_len, 1);
+        assert_eq!(resp.in_path, vec![0xA1, 0xA2, 0xA3]);
+    }
+
+    #[test]
+    fn test_parse_path_discovery_response_outbound_truncated() {
+        let mut data = vec![0x00]; // reserved
+        data.extend_from_slice(&[0xBB; 6]); // pubkey prefix
+                                            // out_path: hash_len=1, path_len=5 (needs 5 bytes)
+        data.push(0b00_000101);
+        data.extend_from_slice(&[0x01, 0x02]); // only 2 bytes, need 5
+
+        assert!(parse_path_discovery_response(&data).is_err());
+    }
+
+    #[test]
+    fn test_parse_path_discovery_response_inbound_truncated() {
+        let mut data = vec![0x00]; // reserved
+        data.extend_from_slice(&[0xCC; 6]); // pubkey prefix
+        data.push(0x00); // out_path: no hops
+                         // in_path: hash_len=1, path_len=2 (needs 2 bytes)
+        data.push(0b00_000010);
+        data.push(0xDD); // only 1 byte, need 2
+
+        assert!(parse_path_discovery_response(&data).is_err());
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -546,11 +546,15 @@ impl MessageReader {
                 self.dispatcher.emit(event).await;
             }
 
-            PacketType::BinaryReq => {}
-            PacketType::FactoryReset => {}
-            PacketType::PathDiscovery => {}
-            PacketType::SetFloodScope => {}
-            PacketType::SendControlData => {}
+            // Command codes (app -> radio direction only). The radio responds
+            // with different packet types (Ok, BinaryResponse, etc.), never
+            // by echoing these codes back. They exist in PacketType because
+            // the same byte values serve as command identifiers on the wire.
+            PacketType::BinaryReq
+            | PacketType::FactoryReset
+            | PacketType::PathDiscovery
+            | PacketType::SetFloodScope
+            | PacketType::SendControlData => {}
 
             PacketType::RawData => {
                 let raw_data = parse_raw_data(payload)?;
@@ -564,6 +568,7 @@ impl MessageReader {
                 self.dispatcher.emit(event).await;
             }
 
+            // TODO: parse path discovery response (#74)
             PacketType::PathDiscoveryResponse => {}
             _ => {
                 tracing::debug!("Unknown packet type: {:?}", packet_type);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -568,8 +568,16 @@ impl MessageReader {
                 self.dispatcher.emit(event).await;
             }
 
-            // TODO: parse path discovery response (#74)
-            PacketType::PathDiscoveryResponse => {}
+            PacketType::PathDiscoveryResponse => {
+                let resp = parse_path_discovery_response(payload)?;
+                let prefix_hex = hex_encode(&resp.pubkey_prefix);
+                let event = MeshCoreEvent::new(
+                    EventType::PathDiscoveryResponse,
+                    EventPayload::PathDiscoveryResponse(resp),
+                )
+                .with_attribute("prefix", prefix_hex);
+                self.dispatcher.emit(event).await;
+            }
             _ => {
                 tracing::debug!("Unknown packet type: {:?}", packet_type);
                 let event = MeshCoreEvent::new(EventType::Unknown, EventPayload::Bytes(data));
@@ -2617,5 +2625,48 @@ mod tests {
             result.is_err(),
             "Command-only packet types should not emit events"
         );
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_path_discovery_response() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        let mut data = vec![PacketType::PathDiscoveryResponse as u8];
+        data.push(0x00); // reserved
+        data.extend_from_slice(&[0xAA; 6]); // pubkey prefix
+                                            // out_path: hash_len=1, path_len=1
+        data.push(0b00_000001);
+        data.push(0x11); // one hop
+                         // in_path: hash_len=1, path_len=0
+        data.push(0x00);
+
+        reader.handle_rx(data).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(100), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(event.event_type, EventType::PathDiscoveryResponse);
+        match event.payload {
+            EventPayload::PathDiscoveryResponse(resp) => {
+                assert_eq!(resp.pubkey_prefix, [0xAA; 6]);
+                assert_eq!(resp.out_path_len, 1);
+                assert_eq!(resp.out_path, vec![0x11]);
+                assert_eq!(resp.in_path_len, 0);
+                assert!(resp.in_path.is_empty());
+            }
+            _ => panic!("Expected PathDiscoveryResponse payload"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_handle_rx_path_discovery_response_too_short() {
+        let (reader, _dispatcher) = create_reader();
+
+        // Too short for PathDiscoveryResponse
+        let data = vec![PacketType::PathDiscoveryResponse as u8, 0x00, 0x01];
+        assert!(reader.handle_rx(data).await.is_err());
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2593,4 +2593,29 @@ mod tests {
         // Falls back to generic BinaryResponse
         assert_eq!(event.event_type, EventType::BinaryResponse);
     }
+
+    #[tokio::test]
+    async fn test_handle_rx_command_only_packet_types_ignored() {
+        let (reader, dispatcher) = create_reader();
+        let mut receiver = dispatcher.receiver();
+
+        // These are outbound command codes that should be silently ignored
+        // when received as inbound packets.
+        for packet_type_byte in [
+            PacketType::BinaryReq as u8,
+            PacketType::FactoryReset as u8,
+            PacketType::PathDiscovery as u8,
+            PacketType::SetFloodScope as u8,
+            PacketType::SendControlData as u8,
+        ] {
+            reader.handle_rx(vec![packet_type_byte]).await.unwrap();
+        }
+
+        // None of them should emit any event
+        let result = tokio::time::timeout(Duration::from_millis(50), receiver.recv()).await;
+        assert!(
+            result.is_err(),
+            "Command-only packet types should not emit events"
+        );
+    }
 }


### PR DESCRIPTION
Add `send_path_discovery()` and `send_path_discovery_with_timeout()` methods to `CommandHandler`.

Wire format: `[CMD_PATH_DISCOVERY=0x34][0x00][pubkey: 32]`, matching the Python reference implementation.

The command sends the path discovery request, waits for `MsgSent` confirmation, then waits for a `PathDiscoveryResponse` event containing the outbound and inbound paths.

Depends on #74 (PR #79) for the `PathDiscoveryResponse` parsing.

Fixes #75