### PR TITLE
Add get_/set_autoadd_config commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,27 +205,43 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 
 The companion firmware (`meshcore-dev/MeshCore`, `examples/companion_radio/MyMesh.cpp`) exposes
 more `CMD_*` commands than this crate currently wraps. The table below lists every command with
-no equivalent here yet, with the minimum firmware version that introduced it
+no equivalent here yet — including a few whose `CMD_*` byte constant is declared in
+`src/commands/base.rs` but marked `#[allow(dead_code)]`, i.e. reserved but never actually sent —
+with the minimum firmware version that introduced it, and whether the reference Python client
+(`meshcore-dev/meshcore_py`) already supports it (checked directly against its source, not
+assumed).
 
-| Code | Name | Description | Minimum firmware version |
-|---|---|---|---|
-| 36 (0x24) | `SEND_TRACE_PATH` | Trace/test the route to a node | companion-v1.4.0 |
-| 37 (0x25) | `SET_DEVICE_PIN` | Set a device PIN (BLE pairing) | companion-v1.4.0 |
-| 38 (0x26) | `SET_OTHER_PARAMS` | Legacy `manual_add_contacts` flag, telemetry mode, advert location policy, multi-acks | companion-v1.5.0 |
-| 39 (0x27) | `SEND_TELEMETRY_REQ` | Request telemetry from a contact — **deprecated in firmware** in favor of `SEND_BINARY_REQ` (already supported, see `req_telemetry()`) | companion-v1.6.0 |
-| 42 (0x2A) | `GET_ADVERT_PATH` | Last known route recorded for a contact's public key | companion-v1.7.1 |
-| 43 (0x2B) | `GET_TUNING_PARAMS` | Read radio tuning params (rx delay base, airtime factor) — the `SET` side is already supported | companion-v1.7.3 |
-| 51 (0x33) | `FACTORY_RESET` | Factory reset (requires the literal `"reset"` confirmation payload) | companion-v1.7.3 |
-| 52 (0x34) | `SEND_PATH_DISCOVERY_REQ` | Actively discover the route to a contact | companion-v1.8.0 |
-| 55 (0x37) | `SEND_CONTROL_DATA` | Send a zero-hop "control" datagram to a peer | companion-v1.10.0 |
-| 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0  |
-| 57 (0x39) | `SEND_ANON_REQ` | Request to a peer that isn't (yet) a known contact | companion-v1.12.0  |
-| 60 (0x3C) | `GET_ALLOWED_REPEAT_FREQ` | Frequency ranges a repeater is allowed to retransmit on | companion-v1.13.0 |
-| 61 (0x3D) | `SET_PATH_HASH_MODE` | Path-hash size mode used when building routes | companion-v1.14.0 |
-| 62 (0x3E) | `SEND_CHANNEL_DATA` | Send a raw datagram on a group/channel | companion-v1.15.0 |
-| 63 (0x3F) | `SET_DEFAULT_FLOOD_SCOPE` | Default flood-scope (region) applied when none is given | companion-v1.15.0 |
-| 64 (0x40) | `GET_DEFAULT_FLOOD_SCOPE` | Read the currently configured default flood-scope | companion-v1.15.0 |
-| 65 (0x41) | `SEND_RAW_PACKET` | Inject a raw, fully-formed mesh packet directly onto the radio | companion-v1.16.0 |
+| Code | Name | Description | Minimum firmware version | In `meshcore_py`? |
+|---|---|---|---|---|
+| 11 (0x0B) | `SET_RADIO_PARAMS` | Set radio freq/bandwidth/spreading factor/coding rate | companion-v1.0.0a | ✅ `set_radio()` |
+| 13 (0x0D) | `RESET_PATH` | Reset a contact's known route back to flood routing | companion-v1.0.0a | ✅ `reset_path()` |
+| 16 (0x10) | `SHARE_CONTACT` | Re-share a known contact's advert with the mesh | companion-v1.0.0a | ✅ `share_contact()` |
+| 21 (0x15) | `SET_TUNING_PARAMS` | Set radio tuning params (rx delay base, airtime factor) | companion-v1.0.0a | ✅ `set_tuning()` |
+| 25 (0x19) | `SEND_RAW_DATA` | Send an opaque `RAW_CUSTOM` payload to a peer | companion-v1.0.0a | ✅ `send_raw_data()` |
+| 27 (0x1B) | `SEND_STATUS_REQ` | Request a contact's status | companion-v1.0.0a | ✅ `send_statusreq()` |
+| 28 (0x1C) | `HAS_CONNECTION` | Whether the node has an active BLE/serial companion connection | companion-v1.0.0a | ✅ `has_connection()` |
+| 30 (0x1E) | `GET_CONTACT_BY_KEY` | Look up a contact by its full public key | companion-v1.2.0 | ✅ `get_contact_by_key()` |
+| 36 (0x24) | `SEND_TRACE_PATH` | Trace/test the route to a node | companion-v1.4.0 | ✅ `send_trace()` |
+| 37 (0x25) | `SET_DEVICE_PIN` | Set a device PIN (BLE pairing) | companion-v1.4.0 | ✅ `set_devicepin()` |
+| 38 (0x26) | `SET_OTHER_PARAMS` | Legacy `manual_add_contacts` flag, telemetry mode, advert location policy, multi-acks | companion-v1.5.0 | ✅ `set_other_params()`/`set_other_params_from_infos()` |
+| 39 (0x27) | `SEND_TELEMETRY_REQ` | Request telemetry from a contact — **deprecated in firmware** in favor of `SEND_BINARY_REQ` (already supported here, see `req_telemetry()`) | companion-v1.6.0 | ✅ `send_telemetry_req()` |
+| 42 (0x2A) | `GET_ADVERT_PATH` | Last known route recorded for a contact's public key | companion-v1.7.1 | ✅ `get_advert_path()` |
+| 43 (0x2B) | `GET_TUNING_PARAMS` | Read radio tuning params (rx delay base, airtime factor) — note `SET_TUNING_PARAMS` (21, above) isn't actually wired up here either, despite its `CMD_*` constant existing | companion-v1.7.3 | ✅ `get_tuning()` |
+| 51 (0x33) | `FACTORY_RESET` | Factory reset (requires the literal `"reset"` confirmation payload) | companion-v1.7.3 | ✅ `request_factory_reset()`/`confirm_factory_reset()` |
+| 52 (0x34) | `SEND_PATH_DISCOVERY_REQ` | Actively discover the route to a contact | companion-v1.8.0 | ✅ `send_path_discovery()` |
+| 55 (0x37) | `SEND_CONTROL_DATA` | Send a zero-hop "control" datagram to a peer | companion-v1.10.0 | ✅ `send_control_data()` |
+| 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0 | ✅ `get_stats_core()`/`get_stats_radio()`/`get_stats_packets()` |
+| 57 (0x39) | `SEND_ANON_REQ` | Request to a peer that isn't (yet) a known contact | companion-v1.12.0 | ✅ `send_anon_req()` |
+| 60 (0x3C) | `GET_ALLOWED_REPEAT_FREQ` | Frequency ranges a repeater is allowed to retransmit on | companion-v1.13.0 | ✅ `get_allowed_repeat_freq()` |
+| 61 (0x3D) | `SET_PATH_HASH_MODE` | Path-hash size mode used when building routes | companion-v1.14.0 | ✅ `set_path_hash_mode()`/`get_path_hash_mode()` |
+| 62 (0x3E) | `SEND_CHANNEL_DATA` | Send a raw datagram on a group/channel | companion-v1.15.0 | ❌ not found in `meshcore_py` either |
+| 63 (0x3F) | `SET_DEFAULT_FLOOD_SCOPE` | Default flood-scope (region) applied when none is given | companion-v1.15.0 | ✅ `set_default_flood_scope()` |
+| 64 (0x40) | `GET_DEFAULT_FLOOD_SCOPE` | Read the currently configured default flood-scope | companion-v1.15.0 | ✅ `get_default_flood_scope()` |
+| 65 (0x41) | `SEND_RAW_PACKET` | Inject a raw, fully-formed mesh packet directly onto the radio | companion-v1.16.0 | ❌ not found in `meshcore_py` either |
+
+`get_autoadd_config()`/`set_autoadd_config()` (58/59, implemented in this PR) are also in
+`meshcore_py` (`contact.py`, `get_autoadd_config()`/`set_autoadd_config()`), since companion-v1.12.0
+(`FIRMWARE_VER_CODE` 8) — not present on older firmware.
 
 ## Protocol Details
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `set_tx_power()` - Set transmission power
 - `send_advert()` - Send advertisement
 - `get_channel()` / `set_channel()` - Get/set channel config
+- `get_autoadd_config()` / `set_autoadd_config()` - Get/set auto-add-contacts configuration (contact-type bitmask + max hops)
 - `export_private_key()` / `import_private_key()` - Key management
 
 ### Contact Commands
@@ -235,10 +236,6 @@ assumed).
 | 63 (0x3F) | `SET_DEFAULT_FLOOD_SCOPE` | Default flood-scope (region) applied when none is given | companion-v1.15.0 | ✅ `set_default_flood_scope()` |
 | 64 (0x40) | `GET_DEFAULT_FLOOD_SCOPE` | Read the currently configured default flood-scope | companion-v1.15.0 | ✅ `get_default_flood_scope()` |
 | 65 (0x41) | `SEND_RAW_PACKET` | Inject a raw, fully-formed mesh packet directly onto the radio | companion-v1.16.0 | ❌ not found in `meshcore_py` either |
-
-`get_autoadd_config()`/`set_autoadd_config()` (58/59, implemented in this PR) are also in
-`meshcore_py` (`contact.py`, `get_autoadd_config()`/`set_autoadd_config()`), since companion-v1.12.0
-(`FIRMWARE_VER_CODE` 8) — not present on older firmware.
 
 ## Protocol Details
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `set_tx_power()` - Set transmission power
 - `send_advert()` - Send advertisement
 - `get_channel()` / `set_channel()` - Get/set channel config
-- `get_autoadd_config()` / `set_autoadd_config()` - Get/set auto-add-contacts configuration (contact-type bitmask + max hops)
+- `get_autoadd_config()` - Get auto-add-contacts flags (contact-type bitmask + the table-full "overwrite oldest" bit)
+- `set_autoadd_config()` - Set auto-add-contacts flags, with an optional max-hop limit
 - `export_private_key()` / `import_private_key()` - Key management
 
 ### Contact Commands

--- a/README.md
+++ b/README.md
@@ -227,9 +227,6 @@ assumed).
 | 39 (0x27) | `SEND_TELEMETRY_REQ` | Request telemetry from a contact — **deprecated in firmware** in favor of `SEND_BINARY_REQ` (already supported here, see `req_telemetry()`) | companion-v1.6.0 | ✅ `send_telemetry_req()` |
 | 42 (0x2A) | `GET_ADVERT_PATH` | Last known route recorded for a contact's public key | companion-v1.7.1 | ✅ `get_advert_path()` |
 | 43 (0x2B) | `GET_TUNING_PARAMS` | Read radio tuning params (rx delay base, airtime factor) — note `SET_TUNING_PARAMS` (21, above) isn't actually wired up here either, despite its `CMD_*` constant existing | companion-v1.7.3 | ✅ `get_tuning()` |
-| 51 (0x33) | `FACTORY_RESET` | Factory reset (requires the literal `"reset"` confirmation payload) | companion-v1.7.3 | ✅ `request_factory_reset()`/`confirm_factory_reset()` |
-| 52 (0x34) | `SEND_PATH_DISCOVERY_REQ` | Actively discover the route to a contact | companion-v1.8.0 | ✅ `send_path_discovery()` |
-| 55 (0x37) | `SEND_CONTROL_DATA` | Send a zero-hop "control" datagram to a peer | companion-v1.10.0 | ✅ `send_control_data()` |
 | 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0 | ✅ `get_stats_core()`/`get_stats_radio()`/`get_stats_packets()` |
 | 57 (0x39) | `SEND_ANON_REQ` | Request to a peer that isn't (yet) a known contact | companion-v1.12.0 | ✅ `send_anon_req()` |
 | 60 (0x3C) | `GET_ALLOWED_REPEAT_FREQ` | Frequency ranges a repeater is allowed to retransmit on | companion-v1.13.0 | ✅ `get_allowed_repeat_freq()` |

--- a/README.md
+++ b/README.md
@@ -201,6 +201,32 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `sign_start()` / `sign_data()` / `sign_finish()` - Low-level signing
 - `sign()` - High-level sign helper
 
+## Not Yet Supported Commands
+
+The companion firmware (`meshcore-dev/MeshCore`, `examples/companion_radio/MyMesh.cpp`) exposes
+more `CMD_*` commands than this crate currently wraps. The table below lists every command with
+no equivalent here yet, with the minimum firmware version that introduced it
+
+| Code | Name | Description | Minimum firmware version |
+|---|---|---|---|
+| 36 (0x24) | `SEND_TRACE_PATH` | Trace/test the route to a node | companion-v1.4.0 |
+| 37 (0x25) | `SET_DEVICE_PIN` | Set a device PIN (BLE pairing) | companion-v1.4.0 |
+| 38 (0x26) | `SET_OTHER_PARAMS` | Legacy `manual_add_contacts` flag, telemetry mode, advert location policy, multi-acks | companion-v1.5.0 |
+| 39 (0x27) | `SEND_TELEMETRY_REQ` | Request telemetry from a contact — **deprecated in firmware** in favor of `SEND_BINARY_REQ` (already supported, see `req_telemetry()`) | companion-v1.6.0 |
+| 42 (0x2A) | `GET_ADVERT_PATH` | Last known route recorded for a contact's public key | companion-v1.7.1 |
+| 43 (0x2B) | `GET_TUNING_PARAMS` | Read radio tuning params (rx delay base, airtime factor) — the `SET` side is already supported | companion-v1.7.3 |
+| 51 (0x33) | `FACTORY_RESET` | Factory reset (requires the literal `"reset"` confirmation payload) | companion-v1.7.3 |
+| 52 (0x34) | `SEND_PATH_DISCOVERY_REQ` | Actively discover the route to a contact | companion-v1.8.0 |
+| 55 (0x37) | `SEND_CONTROL_DATA` | Send a zero-hop "control" datagram to a peer | companion-v1.10.0 |
+| 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0  |
+| 57 (0x39) | `SEND_ANON_REQ` | Request to a peer that isn't (yet) a known contact | companion-v1.12.0  |
+| 60 (0x3C) | `GET_ALLOWED_REPEAT_FREQ` | Frequency ranges a repeater is allowed to retransmit on | companion-v1.13.0 |
+| 61 (0x3D) | `SET_PATH_HASH_MODE` | Path-hash size mode used when building routes | companion-v1.14.0 |
+| 62 (0x3E) | `SEND_CHANNEL_DATA` | Send a raw datagram on a group/channel | companion-v1.15.0 |
+| 63 (0x3F) | `SET_DEFAULT_FLOOD_SCOPE` | Default flood-scope (region) applied when none is given | companion-v1.15.0 |
+| 64 (0x40) | `GET_DEFAULT_FLOOD_SCOPE` | Read the currently configured default flood-scope | companion-v1.15.0 |
+| 65 (0x41) | `SEND_RAW_PACKET` | Inject a raw, fully-formed mesh packet directly onto the radio | companion-v1.16.0 |
+
 ## Protocol Details
 
 The library implements the MeshCore serial/TCP protocol:

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -498,13 +498,36 @@ impl CommandHandler {
     /// [`crate::AUTO_ADD_OVERWRITE_OLDEST`], which isn't a contact type but
     /// controls table-full behavior); 0 means disabled for every type.
     ///
+    /// Introduced in companion firmware `companion-v1.12.0`
+    /// (`FIRMWARE_VER_CODE` 8, from [`SelfInfo::fw_version_code`] after
+    /// [`CommandHandler::send_appstart`]). On older firmware the command
+    /// byte is unrecognized and the node replies with an error frame
+    /// (`ERR_CODE_UNSUPPORTED_CMD`), surfaced here as `Err(Error::Device(_))`
+    /// rather than a timeout.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn example(handler: meshcore_rs::commands::CommandHandler) -> meshcore_rs::Result<()> {
+    /// let flags = handler.get_autoadd_config().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// Format: [CMD_GET_AUTOADD_CONFIG=59]
     pub async fn get_autoadd_config(&self) -> Result<u8> {
         let data = [CMD_GET_AUTOADD_CONFIG];
-        let event = self.send(&data, Some(EventType::AutoAddConfig)).await?;
+        let event = self
+            .send_multi(
+                &data,
+                &[EventType::AutoAddConfig, EventType::Error],
+                self.default_timeout,
+            )
+            .await?;
 
         match event.payload {
             EventPayload::AutoAddConfig { flags } => Ok(flags),
+            EventPayload::String(msg) => Err(Error::device(msg)),
             _ => Err(Error::protocol(
                 "Unexpected response to auto-add config query",
             )),
@@ -517,6 +540,13 @@ impl CommandHandler {
     /// for every contact type. `max_hops`, if given, caps the hop count
     /// eligible for auto-adding; omitted, the firmware leaves its current
     /// value untouched.
+    ///
+    /// Introduced in companion firmware `companion-v1.12.0`
+    /// (`FIRMWARE_VER_CODE` 8, from [`SelfInfo::fw_version_code`] after
+    /// [`CommandHandler::send_appstart`]). On older firmware the command
+    /// byte is unrecognized and the node replies with an error frame
+    /// (`ERR_CODE_UNSUPPORTED_CMD`), surfaced here as `Err(Error::Device(_))`
+    /// rather than a timeout.
     ///
     /// # Example
     ///
@@ -541,7 +571,20 @@ impl CommandHandler {
         if let Some(max_hops) = max_hops {
             data.push(max_hops);
         }
-        self.send(&data, Some(EventType::Ok)).await?;
+        let event = self
+            .send_multi(
+                &data,
+                &[EventType::Ok, EventType::Error],
+                self.default_timeout,
+            )
+            .await?;
+
+        if event.event_type == EventType::Error {
+            return match event.payload {
+                EventPayload::String(msg) => Err(Error::device(msg)),
+                _ => Err(Error::device("Unknown error")),
+            };
+        }
         Ok(())
     }
 
@@ -2087,6 +2130,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_autoadd_config_errors_on_unsupported_command() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+
+            // Firmware older than companion-v1.12.0 doesn't recognize
+            // CMD_GET_AUTOADD_CONFIG and replies with an error frame
+            // (ERR_CODE_UNSUPPORTED_CMD) instead of AutoAddConfig.
+            dispatcher_clone
+                .emit(MeshCoreEvent::error("Unsupported command"))
+                .await;
+        });
+
+        let result = handler.get_autoadd_config().await;
+        assert!(matches!(result, Err(Error::Device(_))));
+    }
+
+    #[tokio::test]
     async fn test_set_autoadd_config_without_max_hops_wire_format() {
         let (handler, mut rx, dispatcher) = create_test_handler();
 
@@ -2124,6 +2187,26 @@ mod tests {
 
         let result = handler.set_autoadd_config(config, Some(5)).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_set_autoadd_config_errors_on_unsupported_command() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+
+            // Firmware older than companion-v1.12.0 doesn't recognize
+            // CMD_SET_AUTOADD_CONFIG and replies with an error frame
+            // (ERR_CODE_UNSUPPORTED_CMD) instead of Ok.
+            dispatcher_clone
+                .emit(MeshCoreEvent::error("Unsupported command"))
+                .await;
+        });
+
+        let result = handler.set_autoadd_config(0, None).await;
+        assert!(matches!(result, Err(Error::Device(_))));
     }
 
     #[tokio::test]

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{broadcast, mpsc};
 
 use crate::events::*;
 use crate::packets::BinaryReqType;
@@ -215,15 +215,20 @@ impl CommandHandler {
         expected_event: Option<EventType>,
         timeout: Duration,
     ) -> Result<MeshCoreEvent> {
-        // Send the data
+        // Subscribe before sending -- otherwise a response that arrives between the send
+        // and subscribing would be missed (broadcast receivers only see events sent after
+        // they subscribe).
+        let mut rx = self.dispatcher.receiver();
+
         self.sender
             .send(data.to_vec())
             .await
             .map_err(|e| Error::Channel(e.to_string()))?;
 
-        // Wait for response
-        self.wait_for_event(expected_event, HashMap::new(), timeout)
+        self.dispatcher
+            .wait_for_event_on(&mut rx, expected_event, HashMap::new(), timeout)
             .await
+            .ok_or_else(|| Error::timeout(format!("{:?}", expected_event)))
     }
 
     /// Send raw data and wait for one of multiple response types
@@ -233,14 +238,15 @@ impl CommandHandler {
         expected_events: &[EventType],
         timeout: Duration,
     ) -> Result<MeshCoreEvent> {
-        // Send the data
+        // Subscribe before sending -- see send_with_timeout.
+        let mut rx = self.dispatcher.receiver();
+
         self.sender
             .send(data.to_vec())
             .await
             .map_err(|e| Error::Channel(e.to_string()))?;
 
-        // Wait for any of the expected events
-        self.wait_for_any_event(expected_events, timeout).await
+        Self::wait_for_any_event_on(&mut rx, expected_events, timeout).await
     }
 
     /// Wait for a specific event
@@ -263,7 +269,19 @@ impl CommandHandler {
         timeout: Duration,
     ) -> Result<MeshCoreEvent> {
         let mut rx = self.dispatcher.receiver();
+        Self::wait_for_any_event_on(&mut rx, event_types, timeout).await
+    }
 
+    /// Wait for any of the specified events on an already-subscribed receiver.
+    ///
+    /// Callers that both trigger a response and then wait for it should subscribe with
+    /// [`EventDispatcher::receiver`] *before* triggering it, then wait here -- see
+    /// [`EventDispatcher::wait_for_event_on`] for why.
+    async fn wait_for_any_event_on(
+        rx: &mut broadcast::Receiver<MeshCoreEvent>,
+        event_types: &[EventType],
+        timeout: Duration,
+    ) -> Result<MeshCoreEvent> {
         tokio::select! {
             _ = tokio::time::sleep(timeout) => {
                 Err(Error::timeout("response"))
@@ -499,8 +517,8 @@ impl CommandHandler {
     /// controls table-full behavior); 0 means disabled for every type.
     ///
     /// Introduced in companion firmware `companion-v1.12.0`
-    /// (`FIRMWARE_VER_CODE` 8, from [`SelfInfo::fw_version_code`] after
-    /// [`CommandHandler::send_appstart`]). On older firmware the command
+    /// (`FIRMWARE_VER_CODE` 8, from [`DeviceInfoData::fw_version_code`] after
+    /// [`CommandHandler::send_device_query`]). On older firmware the command
     /// byte is unrecognized and the node replies with an error frame
     /// (`ERR_CODE_UNSUPPORTED_CMD`), surfaced here as `Err(Error::Device(_))`
     /// rather than a timeout.
@@ -542,8 +560,8 @@ impl CommandHandler {
     /// value untouched.
     ///
     /// Introduced in companion firmware `companion-v1.12.0`
-    /// (`FIRMWARE_VER_CODE` 8, from [`SelfInfo::fw_version_code`] after
-    /// [`CommandHandler::send_appstart`]). On older firmware the command
+    /// (`FIRMWARE_VER_CODE` 8, from [`DeviceInfoData::fw_version_code`] after
+    /// [`CommandHandler::send_device_query`]). On older firmware the command
     /// byte is unrecognized and the node replies with an error frame
     /// (`ERR_CODE_UNSUPPORTED_CMD`), surfaced here as `Err(Error::Device(_))`
     /// rather than a timeout.

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -2064,6 +2064,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_autoadd_config_errors_on_mismatched_payload() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+
+            // Right EventType, wrong payload shape -- shouldn't happen via
+            // the real reader (type and payload are always constructed
+            // together), but exercises the defensive fallback arm.
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::AutoAddConfig,
+                    EventPayload::None,
+                ))
+                .await;
+        });
+
+        let result = handler.get_autoadd_config().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn test_set_autoadd_config_without_max_hops_wire_format() {
         let (handler, mut rx, dispatcher) = create_test_handler();
 

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -545,6 +545,8 @@ impl CommandHandler {
 
         match event.payload {
             EventPayload::AutoAddConfig { flags } => Ok(flags),
+            // e.g. the unsupported-command error frame on firmware older than
+            // companion-v1.12.0 (see doc comment above).
             EventPayload::String(msg) => Err(Error::device(msg)),
             _ => Err(Error::protocol(
                 "Unexpected response to auto-add config query",
@@ -2164,7 +2166,10 @@ mod tests {
         });
 
         let result = handler.get_autoadd_config().await;
-        assert!(matches!(result, Err(Error::Device(_))));
+        match result {
+            Err(Error::Device(msg)) => assert_eq!(msg, "Unsupported command"),
+            other => panic!("expected Err(Error::Device(\"Unsupported command\")), got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -2224,7 +2229,10 @@ mod tests {
         });
 
         let result = handler.set_autoadd_config(0, None).await;
-        assert!(matches!(result, Err(Error::Device(_))));
+        match result {
+            Err(Error::Device(msg)) => assert_eq!(msg, "Unsupported command"),
+            other => panic!("expected Err(Error::Device(\"Unsupported command\")), got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -2244,7 +2252,10 @@ mod tests {
         });
 
         let result = handler.set_autoadd_config(0, None).await;
-        assert!(matches!(result, Err(Error::Device(_))));
+        match result {
+            Err(Error::Device(msg)) => assert_eq!(msg, "Unknown error"),
+            other => panic!("expected Err(Error::Device(\"Unknown error\")), got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -2228,6 +2228,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_set_autoadd_config_errors_on_malformed_error_payload() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+
+            // Right EventType, wrong payload shape -- shouldn't happen via
+            // the real reader (type and payload are always constructed
+            // together), but exercises the defensive fallback arm.
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::Error, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.set_autoadd_config(0, None).await;
+        assert!(matches!(result, Err(Error::Device(_))));
+    }
+
+    #[tokio::test]
     async fn test_sign_start_success() {
         let (handler, mut rx, dispatcher) = create_test_handler();
 

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -65,6 +65,8 @@ const CMD_FACTORY_RESET: u8 = 51;
 const CMD_PATH_DISCOVERY: u8 = 52;
 const CMD_SET_FLOOD_SCOPE: u8 = 54;
 const CMD_SEND_CONTROL_DATA: u8 = 55;
+const CMD_SET_AUTOADD_CONFIG: u8 = 58;
+const CMD_GET_AUTOADD_CONFIG: u8 = 59;
 
 /// Destination type for commands
 #[derive(Debug, Clone)]
@@ -485,6 +487,60 @@ impl CommandHandler {
         // name_bytes[name_len..] is already zero (null terminator guaranteed)
         data.extend_from_slice(&name_bytes);
         data.extend_from_slice(secret);
+        self.send(&data, Some(EventType::Ok)).await?;
+        Ok(())
+    }
+
+    /// Get auto-add-contacts configuration: a bitmask of contact types
+    /// eligible for automatic addition from overheard adverts (see
+    /// [`crate::AUTO_ADD_CHAT`], [`crate::AUTO_ADD_REPEATER`],
+    /// [`crate::AUTO_ADD_ROOM_SERVER`], [`crate::AUTO_ADD_SENSOR`], plus
+    /// [`crate::AUTO_ADD_OVERWRITE_OLDEST`], which isn't a contact type but
+    /// controls table-full behavior); 0 means disabled for every type.
+    ///
+    /// Format: [CMD_GET_AUTOADD_CONFIG=59]
+    pub async fn get_autoadd_config(&self) -> Result<u8> {
+        let data = [CMD_GET_AUTOADD_CONFIG];
+        let event = self.send(&data, Some(EventType::AutoAddConfig)).await?;
+
+        match event.payload {
+            EventPayload::AutoAddConfig { flags } => Ok(flags),
+            _ => Err(Error::protocol(
+                "Unexpected response to auto-add config query",
+            )),
+        }
+    }
+
+    /// Set auto-add-contacts configuration. `config` is built by OR-ing
+    /// together the `AUTO_ADD_*` bit constants (e.g.
+    /// `AUTO_ADD_REPEATER | AUTO_ADD_ROOM_SERVER`); `0` disables auto-add
+    /// for every contact type. `max_hops`, if given, caps the hop count
+    /// eligible for auto-adding; omitted, the firmware leaves its current
+    /// value untouched.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use meshcore_rs::{AUTO_ADD_REPEATER, AUTO_ADD_ROOM_SERVER};
+    /// # async fn example(handler: meshcore_rs::commands::CommandHandler) -> meshcore_rs::Result<()> {
+    /// // Only auto-add repeaters and room servers, capped at 3 hops.
+    /// handler
+    ///     .set_autoadd_config(AUTO_ADD_REPEATER | AUTO_ADD_ROOM_SERVER, Some(3))
+    ///     .await?;
+    ///
+    /// // Disable auto-add entirely.
+    /// handler.set_autoadd_config(0, None).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Format: [CMD_SET_AUTOADD_CONFIG=58][config: u8]
+    /// Format: [CMD_SET_AUTOADD_CONFIG=58][config: u8][max_hops: u8]
+    pub async fn set_autoadd_config(&self, config: u8, max_hops: Option<u8>) -> Result<()> {
+        let mut data = vec![CMD_SET_AUTOADD_CONFIG, config];
+        if let Some(max_hops) = max_hops {
+            data.push(max_hops);
+        }
         self.send(&data, Some(EventType::Ok)).await?;
         Ok(())
     }
@@ -1137,6 +1193,9 @@ impl CommandHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        AUTO_ADD_CHAT, AUTO_ADD_OVERWRITE_OLDEST, AUTO_ADD_REPEATER, AUTO_ADD_ROOM_SERVER,
+    };
 
     // ========== Destination Tests ==========
 
@@ -1978,6 +2037,69 @@ mod tests {
         // Name longer than CHANNEL_NAME_LEN - 1 should be truncated to ensure null termination
         let long_name = "This is a very long channel name that exceeds the limit";
         let result = handler.set_channel(2, long_name, &secret).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_autoadd_config_success() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_AUTOADD_CONFIG]);
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::AutoAddConfig,
+                    EventPayload::AutoAddConfig {
+                        flags: AUTO_ADD_OVERWRITE_OLDEST | AUTO_ADD_CHAT,
+                    },
+                ))
+                .await;
+        });
+
+        let result = handler.get_autoadd_config().await;
+        assert_eq!(result.unwrap(), AUTO_ADD_OVERWRITE_OLDEST | AUTO_ADD_CHAT);
+    }
+
+    #[tokio::test]
+    async fn test_set_autoadd_config_without_max_hops_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            // No max_hops byte -- exactly [CMD, config].
+            assert_eq!(sent, vec![CMD_SET_AUTOADD_CONFIG, 0]);
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::Ok, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.set_autoadd_config(0, None).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_set_autoadd_config_with_max_hops_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        let config =
+            AUTO_ADD_OVERWRITE_OLDEST | AUTO_ADD_CHAT | AUTO_ADD_REPEATER | AUTO_ADD_ROOM_SERVER;
+
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_SET_AUTOADD_CONFIG, config, 5]);
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::Ok, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.set_autoadd_config(config, Some(5)).await;
         assert!(result.is_ok());
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -822,7 +822,23 @@ impl EventDispatcher {
         timeout: std::time::Duration,
     ) -> Option<MeshCoreEvent> {
         let mut rx = self.broadcast_tx.subscribe();
+        self.wait_for_event_on(&mut rx, event_type, filters, timeout)
+            .await
+    }
 
+    /// Wait for a specific event type on an already-subscribed receiver.
+    ///
+    /// Callers that both trigger a response (e.g. by sending a command) and then wait
+    /// for it should subscribe with [`Self::receiver`] *before* triggering it, then wait
+    /// here -- otherwise a response emitted between subscribing and waiting is missed,
+    /// since `broadcast` receivers only see events sent after they subscribe.
+    pub async fn wait_for_event_on(
+        &self,
+        rx: &mut broadcast::Receiver<MeshCoreEvent>,
+        event_type: Option<EventType>,
+        filters: HashMap<String, String>,
+        timeout: std::time::Duration,
+    ) -> Option<MeshCoreEvent> {
         tokio::select! {
             _ = tokio::time::sleep(timeout) => None,
             result = async {
@@ -1064,6 +1080,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(received.event_type, EventType::Ok);
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_event_on_receives_event_emitted_before_wait_starts() {
+        // A broadcast receiver buffers events sent after it subscribes, even before
+        // anyone starts polling it with recv()/wait_for_event_on. This is the invariant
+        // CommandHandler::send_with_timeout/send_multi rely on by subscribing before
+        // sending the command that triggers the response: as long as subscribing happens
+        // before the command is sent, an immediate response can never be missed, no
+        // matter how much later wait_for_event_on is actually called.
+        let dispatcher = EventDispatcher::new();
+        let mut rx = dispatcher.receiver();
+
+        dispatcher.emit(MeshCoreEvent::ok()).await;
+
+        let result = dispatcher
+            .wait_for_event_on(
+                &mut rx,
+                Some(EventType::Ok),
+                HashMap::new(),
+                Duration::from_millis(100),
+            )
+            .await;
+
+        assert_eq!(result.unwrap().event_type, EventType::Ok);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,22 @@ pub const CHANNEL_SECRET_LEN: usize = 16;
 /// Total length of channel info payload (idx + name + secret)
 pub const CHANNEL_INFO_LEN: usize = 1 + CHANNEL_NAME_LEN + CHANNEL_SECRET_LEN;
 
+// Auto-add-contacts config bits (`CommandHandler::get_autoadd_config`/
+// `set_autoadd_config`'s `config` byte). Matches firmware's
+// `examples/companion_radio/MyMesh.cpp` `AUTO_ADD_*` defines exactly,
+// including their naming, so the two stay easy to cross-reference.
+/// When set, auto-adding a new contact while the table is full overwrites
+/// the oldest non-favourite entry instead of being rejected.
+pub const AUTO_ADD_OVERWRITE_OLDEST: u8 = 1 << 0;
+/// Auto-add Chat (Companion) contacts (`ADV_TYPE_CHAT`).
+pub const AUTO_ADD_CHAT: u8 = 1 << 1;
+/// Auto-add Repeater contacts (`ADV_TYPE_REPEATER`).
+pub const AUTO_ADD_REPEATER: u8 = 1 << 2;
+/// Auto-add Room Server contacts (`ADV_TYPE_ROOM`).
+pub const AUTO_ADD_ROOM_SERVER: u8 = 1 << 3;
+/// Auto-add Sensor contacts (`ADV_TYPE_SENSOR`).
+pub const AUTO_ADD_SENSOR: u8 = 1 << 4;
+
 pub use error::Error;
 pub use events::{
     ChannelMessage, ContactMessage, EventDispatcher, EventPayload, EventType, MeshCoreEvent,
@@ -103,5 +119,29 @@ mod tests {
         // 1 byte idx + 32 bytes name + 16 bytes secret = 49
         assert_eq!(CHANNEL_INFO_LEN, 49);
         assert_eq!(CHANNEL_INFO_LEN, 1 + CHANNEL_NAME_LEN + CHANNEL_SECRET_LEN);
+    }
+
+    #[test]
+    fn test_auto_add_bits_match_firmware_values() {
+        assert_eq!(AUTO_ADD_OVERWRITE_OLDEST, 0x01);
+        assert_eq!(AUTO_ADD_CHAT, 0x02);
+        assert_eq!(AUTO_ADD_REPEATER, 0x04);
+        assert_eq!(AUTO_ADD_ROOM_SERVER, 0x08);
+        assert_eq!(AUTO_ADD_SENSOR, 0x10);
+    }
+
+    #[test]
+    fn test_auto_add_bits_are_disjoint() {
+        let bits = [
+            AUTO_ADD_OVERWRITE_OLDEST,
+            AUTO_ADD_CHAT,
+            AUTO_ADD_REPEATER,
+            AUTO_ADD_ROOM_SERVER,
+            AUTO_ADD_SENSOR,
+        ];
+        assert_eq!(
+            bits.iter().fold(0u8, |acc, &b| acc | b).count_ones() as usize,
+            bits.len()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `get_autoadd_config()`/`set_autoadd_config()` to `CommandHandler`, sending `CMD_GET_AUTOADD_CONFIG=59`/`CMD_SET_AUTOADD_CONFIG=58` — verified against `examples/companion_radio/MyMesh.cpp`. The response type (`EventType::AutoAddConfig`/`EventPayload::AutoAddConfig`) was already parsed by the reader, but nothing sent the commands.
- Adds `AUTO_ADD_OVERWRITE_OLDEST`/`AUTO_ADD_CHAT`/`AUTO_ADD_REPEATER`/`AUTO_ADD_ROOM_SERVER`/`AUTO_ADD_SENSOR` bitmask constants at the crate root, matching the firmware's own `AUTO_ADD_*` names and values exactly, used in `set_autoadd_config`'s doc example and the wire-format tests (no magic numbers).
- README: new "Not Yet Supported Commands" section listing every companion `CMD_*` this crate doesn't wrap yet, with the minimum firmware version each was introduced in (found via `git log -S` on the firmware repo, mapped to the earliest `companion-v*` tag containing the introduction commit, cross-checked against `FIRMWARE_VER_CODE` where the firmware has an inline version comment).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --tests --no-deps --all-features --all-targets`
- [x] `cargo test --all-features` — 285 tests + 3 doc-tests, all passing
- [x] `cargo build --release` and `cargo publish --dry-run --allow-dirty --no-verify`
- [x] `jonesy` — 0 panic points