### PR TITLE
Add get_stats command with typed core/radio/packet responses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,6 @@ name = "rf_packet_monitor"
 
 [[example]]
 name = "add_remove_contact"
+
+[[example]]
+name = "node_stats"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `send_advert()` - Send advertisement
 - `get_channel()` / `set_channel()` - Get/set channel config
 - `export_private_key()` / `import_private_key()` - Key management
+- `get_core_stats()` / `get_radio_stats()` / `get_packet_stats()` - Device/radio/packet counters (see `examples/node_stats.rs`)
 
 ### Contact Commands
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `get_autoadd_config()` - Get auto-add-contacts flags (contact-type bitmask + the table-full "overwrite oldest" bit)
 - `set_autoadd_config()` - Set auto-add-contacts flags, with an optional max-hop limit
 - `export_private_key()` / `import_private_key()` - Key management
-- `get_core_stats()` / `get_radio_stats()` / `get_packet_stats()` - Device/radio/packet counters (see `examples/node_stats.rs`)
+- `get_core_stats()` - Battery, uptime, error count, queue length
+- `get_radio_stats()` - Noise floor, last RSSI/SNR, cumulative airtime
+- `get_packet_stats()` - Packet counters (see `examples/node_stats.rs`)
 
 ### Contact Commands
 
@@ -230,7 +232,7 @@ assumed).
 | 39 (0x27) | `SEND_TELEMETRY_REQ` | Request telemetry from a contact — **deprecated in firmware** in favor of `SEND_BINARY_REQ` (already supported here, see `req_telemetry()`) | companion-v1.6.0 | ✅ `send_telemetry_req()` |
 | 42 (0x2A) | `GET_ADVERT_PATH` | Last known route recorded for a contact's public key | companion-v1.7.1 | ✅ `get_advert_path()` |
 | 43 (0x2B) | `GET_TUNING_PARAMS` | Read radio tuning params (rx delay base, airtime factor) — note `SET_TUNING_PARAMS` (21, above) isn't actually wired up here either, despite its `CMD_*` constant existing | companion-v1.7.3 | ✅ `get_tuning()` |
-| 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0 | ✅ `get_stats_core()`/`get_stats_radio()`/`get_stats_packets()` |
+| 56 (0x38) | `GET_STATS` | Core/radio/packet statistics (sub-type in byte 2) | companion-v1.11.0 | ✅ `get_core_stats()`/`get_radio_stats()`/`get_packet_stats()` |
 | 57 (0x39) | `SEND_ANON_REQ` | Request to a peer that isn't (yet) a known contact | companion-v1.12.0 | ✅ `send_anon_req()` |
 | 60 (0x3C) | `GET_ALLOWED_REPEAT_FREQ` | Frequency ranges a repeater is allowed to retransmit on | companion-v1.13.0 | ✅ `get_allowed_repeat_freq()` |
 | 61 (0x3D) | `SET_PATH_HASH_MODE` | Path-hash size mode used when building routes | companion-v1.14.0 | ✅ `set_path_hash_mode()`/`get_path_hash_mode()` |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ traffic never triggers it; use `LogData` for general monitoring as above.
 - `get_autoadd_config()` - Get auto-add-contacts flags (contact-type bitmask + the table-full "overwrite oldest" bit)
 - `set_autoadd_config()` - Set auto-add-contacts flags, with an optional max-hop limit
 - `export_private_key()` / `import_private_key()` - Key management
+- `get_core_stats()` / `get_radio_stats()` / `get_packet_stats()` - Device/radio/packet counters (see `examples/node_stats.rs`)
 
 ### Contact Commands
 

--- a/examples/node_stats.rs
+++ b/examples/node_stats.rs
@@ -1,0 +1,84 @@
+//! Example: fetch and print a node's core/radio/packet stats.
+//!
+//! The Rust-side counterpart to `meshcore_py`'s own `examples/ble_stats.py`.
+//! Each category is fetched and reported independently -- one failing (e.g.
+//! older firmware missing `recv_errors` in the packets frame, or a node
+//! that doesn't support `CMD_GET_STATS` at all, pre companion-v1.11.0)
+//! doesn't stop the others from being tried.
+//!
+//! Usage: exactly one of the following is required
+//!   cargo run --example node_stats --features serial -- --serial <port>
+//!   cargo run --example node_stats --features tcp -- --tcp <host:port>
+//!   cargo run --example node_stats --features ble -- --ble <device-name>
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{connect, parse_args, ConnectionArgs};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = match parse_args(std::env::args().skip(1)) {
+        Ok(args) => args,
+        Err(message) => {
+            eprintln!("{message}");
+            std::process::exit(1);
+        }
+    };
+
+    run(args).await
+}
+
+async fn run(args: ConnectionArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let meshcore = connect(&args).await?;
+
+    let self_info = meshcore.commands().lock().await.send_appstart().await?;
+    println!("Connected to device: {}", self_info.name);
+
+    println!("\nFetching core stats...");
+    match meshcore.commands().lock().await.get_core_stats().await {
+        Ok(stats) => {
+            println!("  battery_mv:   {}", stats.battery_mv);
+            println!("  uptime_secs:  {}", stats.uptime_secs);
+            println!("  errors:       {}", stats.errors);
+            println!("  queue_len:    {}", stats.queue_len);
+        }
+        Err(err) => eprintln!("  Error getting core stats: {err}"),
+    }
+
+    println!("\nFetching radio stats...");
+    match meshcore.commands().lock().await.get_radio_stats().await {
+        Ok(stats) => {
+            println!("  noise_floor:  {} dBm", stats.noise_floor);
+            println!("  last_rssi:    {} dBm", stats.last_rssi);
+            println!("  last_snr:     {} dB", stats.last_snr);
+            println!("  tx_air_secs:  {}", stats.tx_air_secs);
+            println!("  rx_air_secs:  {}", stats.rx_air_secs);
+        }
+        Err(err) => eprintln!("  Error getting radio stats: {err}"),
+    }
+
+    println!("\nFetching packet stats...");
+    match meshcore.commands().lock().await.get_packet_stats().await {
+        Ok(stats) => {
+            println!("  recv:         {}", stats.recv);
+            println!("  sent:         {}", stats.sent);
+            println!("  flood_tx:     {}", stats.flood_tx);
+            println!("  direct_tx:    {}", stats.direct_tx);
+            println!("  flood_rx:     {}", stats.flood_rx);
+            println!("  direct_rx:    {}", stats.direct_rx);
+            match stats.recv_errors {
+                Some(errors) => println!("  recv_errors:  {errors}"),
+                None => println!("  recv_errors:  not reported (legacy 26-byte frame)"),
+            }
+        }
+        Err(err) => eprintln!("  Error getting packet stats: {err}"),
+    }
+
+    meshcore.disconnect().await?;
+    Ok(())
+}

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -65,6 +65,7 @@ const CMD_FACTORY_RESET: u8 = 51;
 const CMD_PATH_DISCOVERY: u8 = 52;
 const CMD_SET_FLOOD_SCOPE: u8 = 54;
 const CMD_SEND_CONTROL_DATA: u8 = 55;
+const CMD_GET_STATS: u8 = 56;
 
 /// Destination type for commands
 #[derive(Debug, Clone)]
@@ -558,6 +559,45 @@ impl CommandHandler {
         data.extend_from_slice(control_data);
         self.send(&data, Some(EventType::Ok)).await?;
         Ok(())
+    }
+
+    /// Get raw device stats for one category.
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type]
+    pub async fn get_stats(&self, category: StatsCategory) -> Result<StatsData> {
+        let data = [CMD_GET_STATS, category as u8];
+        let event_type = match category {
+            StatsCategory::Core => EventType::StatsCore,
+            StatsCategory::Radio => EventType::StatsRadio,
+            StatsCategory::Packets => EventType::StatsPackets,
+        };
+        let event = self.send(&data, Some(event_type)).await?;
+
+        match event.payload {
+            EventPayload::Stats(data) => Ok(data),
+            _ => Err(Error::protocol("Unexpected response to stats query")),
+        }
+    }
+
+    /// Get core device stats (battery, uptime, error count, queue length).
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=0]
+    pub async fn get_core_stats(&self) -> Result<CoreStatsData> {
+        self.get_stats(StatsCategory::Core).await?.as_core()
+    }
+
+    /// Get radio stats (noise floor, last RSSI/SNR, cumulative airtime).
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=1]
+    pub async fn get_radio_stats(&self) -> Result<RadioStatsData> {
+        self.get_stats(StatsCategory::Radio).await?.as_radio()
+    }
+
+    /// Get packet counters.
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=2]
+    pub async fn get_packet_stats(&self) -> Result<PacketStatsData> {
+        self.get_stats(StatsCategory::Packets).await?.as_packets()
     }
 
     /// Export private key
@@ -1763,6 +1803,141 @@ mod tests {
 
         let result = handler.send_control_data(&[0x01, 0x02, 0x03]).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_core_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 0]); // stats_type=0 (Core)
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsCore,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Core,
+                        raw: vec![0xAA],
+                    }),
+                ))
+                .await;
+        });
+
+        let result = handler.get_stats(StatsCategory::Core).await;
+        assert_eq!(result.unwrap().raw, vec![0xAA]);
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_unexpected_response_errors() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+            // Right EventType, wrong payload shape.
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::StatsCore, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.get_stats(StatsCategory::Core).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_core_stats_wire_format_and_decoding() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 0]);
+
+            let mut raw = Vec::new();
+            raw.extend_from_slice(&4012u16.to_le_bytes());
+            raw.extend_from_slice(&123456u32.to_le_bytes());
+            raw.extend_from_slice(&0u16.to_le_bytes());
+            raw.push(0);
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsCore,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Core,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_core_stats().await.unwrap();
+        assert_eq!(stats.battery_mv, 4012);
+        assert_eq!(stats.uptime_secs, 123456);
+    }
+
+    #[tokio::test]
+    async fn test_get_radio_stats_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 1]); // stats_type=1 (Radio)
+
+            let mut raw = Vec::new();
+            raw.extend_from_slice(&(-100i16).to_le_bytes());
+            raw.push((-70i8) as u8);
+            raw.push(20i8 as u8); // 20 / 4.0 = 5.0 dB
+            raw.extend_from_slice(&10u32.to_le_bytes());
+            raw.extend_from_slice(&20u32.to_le_bytes());
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsRadio,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Radio,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_radio_stats().await.unwrap();
+        assert_eq!(stats.noise_floor, -100);
+        assert_eq!(stats.last_rssi, -70);
+        assert_eq!(stats.last_snr, 5.0);
+    }
+
+    #[tokio::test]
+    async fn test_get_packet_stats_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 2]); // stats_type=2 (Packets)
+
+            let mut raw = Vec::new();
+            for value in [1000u32, 500, 100, 400, 200, 800] {
+                raw.extend_from_slice(&value.to_le_bytes());
+            }
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsPackets,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Packets,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_packet_stats().await.unwrap();
+        assert_eq!(stats.recv, 1000);
+        assert_eq!(stats.recv_errors, None);
     }
 
     #[tokio::test]

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -680,7 +680,27 @@ impl CommandHandler {
         Ok(())
     }
 
-    /// Get raw device stats for one category.
+    /// Get raw device stats for one category. `get_core_stats()`/
+    /// `get_radio_stats()`/`get_packet_stats()` are typed convenience
+    /// wrappers over this; call this directly for a category that doesn't
+    /// have one yet.
+    ///
+    /// Introduced in companion firmware `FIRMWARE_VER_CODE` 8+ (per the
+    /// firmware's own inline comment on `CMD_GET_STATS`, from
+    /// [`DeviceInfoData::fw_version_code`] after
+    /// [`CommandHandler::send_device_query`]). On older firmware the command
+    /// byte is unrecognized and the node replies with an error frame,
+    /// surfaced here as `Err(Error::Device(_))` rather than a timeout.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use meshcore_rs::events::StatsCategory;
+    /// # async fn example(handler: meshcore_rs::commands::CommandHandler) -> meshcore_rs::Result<()> {
+    /// let stats = handler.get_stats(StatsCategory::Core).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     ///
     /// Format: [CMD_GET_STATS=56][stats_type]
     pub async fn get_stats(&self, category: StatsCategory) -> Result<StatsData> {
@@ -690,31 +710,31 @@ impl CommandHandler {
             StatsCategory::Radio => EventType::StatsRadio,
             StatsCategory::Packets => EventType::StatsPackets,
         };
-        let event = self.send(&data, Some(event_type)).await?;
+        let event = self
+            .send_multi(&data, &[event_type, EventType::Error], self.default_timeout)
+            .await?;
 
         match event.payload {
             EventPayload::Stats(data) => Ok(data),
+            EventPayload::String(msg) => Err(Error::device(msg)),
             _ => Err(Error::protocol("Unexpected response to stats query")),
         }
     }
 
     /// Get core device stats (battery, uptime, error count, queue length).
-    ///
-    /// Format: [CMD_GET_STATS=56][stats_type=0]
+    /// See [`Self::get_stats`] for firmware-version/error-behavior notes.
     pub async fn get_core_stats(&self) -> Result<CoreStatsData> {
         self.get_stats(StatsCategory::Core).await?.as_core()
     }
 
     /// Get radio stats (noise floor, last RSSI/SNR, cumulative airtime).
-    ///
-    /// Format: [CMD_GET_STATS=56][stats_type=1]
+    /// See [`Self::get_stats`] for firmware-version/error-behavior notes.
     pub async fn get_radio_stats(&self) -> Result<RadioStatsData> {
         self.get_stats(StatsCategory::Radio).await?.as_radio()
     }
 
     /// Get packet counters.
-    ///
-    /// Format: [CMD_GET_STATS=56][stats_type=2]
+    /// See [`Self::get_stats`] for firmware-version/error-behavior notes.
     pub async fn get_packet_stats(&self) -> Result<PacketStatsData> {
         self.get_stats(StatsCategory::Packets).await?.as_packets()
     }
@@ -1965,7 +1985,27 @@ mod tests {
         });
 
         let result = handler.get_stats(StatsCategory::Core).await;
-        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_errors_on_unsupported_command() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+
+            // Firmware older than FIRMWARE_VER_CODE 8 doesn't recognize
+            // CMD_GET_STATS and replies with an error frame instead of a
+            // Stats* event.
+            dispatcher_clone
+                .emit(MeshCoreEvent::error("Unsupported command"))
+                .await;
+        });
+
+        let result = handler.get_stats(StatsCategory::Core).await;
+        assert!(matches!(result, Err(Error::Device(_))));
     }
 
     #[tokio::test]
@@ -1977,11 +2017,12 @@ mod tests {
             let sent = rx.recv().await.unwrap();
             assert_eq!(sent, vec![CMD_GET_STATS, 0]);
 
+            // [battery_mv, uptime_secs, errors, queue_len]
             let mut raw = Vec::new();
             raw.extend_from_slice(&4012u16.to_le_bytes());
             raw.extend_from_slice(&123456u32.to_le_bytes());
-            raw.extend_from_slice(&0u16.to_le_bytes());
-            raw.push(0);
+            raw.extend_from_slice(&7u16.to_le_bytes());
+            raw.push(3);
 
             dispatcher_clone
                 .emit(MeshCoreEvent::new(
@@ -1995,8 +2036,10 @@ mod tests {
         });
 
         let stats = handler.get_core_stats().await.unwrap();
-        assert_eq!(stats.battery_mv, 4012);
-        assert_eq!(stats.uptime_secs, 123456);
+        assert_eq!(stats.battery_mv, 4012, "battery_mv");
+        assert_eq!(stats.uptime_secs, 123456, "uptime_secs");
+        assert_eq!(stats.errors, 7, "errors");
+        assert_eq!(stats.queue_len, 3, "queue_len");
     }
 
     #[tokio::test]
@@ -2008,6 +2051,7 @@ mod tests {
             let sent = rx.recv().await.unwrap();
             assert_eq!(sent, vec![CMD_GET_STATS, 1]); // stats_type=1 (Radio)
 
+            // [noise_floor, last_rssi, last_snr_scaled, tx_air_secs, rx_air_secs]
             let mut raw = Vec::new();
             raw.extend_from_slice(&(-100i16).to_le_bytes());
             raw.push((-70i8) as u8);
@@ -2027,9 +2071,11 @@ mod tests {
         });
 
         let stats = handler.get_radio_stats().await.unwrap();
-        assert_eq!(stats.noise_floor, -100);
-        assert_eq!(stats.last_rssi, -70);
-        assert_eq!(stats.last_snr, 5.0);
+        assert_eq!(stats.noise_floor, -100, "noise_floor");
+        assert_eq!(stats.last_rssi, -70, "last_rssi");
+        assert_eq!(stats.last_snr, 5.0, "last_snr");
+        assert_eq!(stats.tx_air_secs, 10, "tx_air_secs");
+        assert_eq!(stats.rx_air_secs, 20, "rx_air_secs");
     }
 
     #[tokio::test]
@@ -2041,6 +2087,7 @@ mod tests {
             let sent = rx.recv().await.unwrap();
             assert_eq!(sent, vec![CMD_GET_STATS, 2]); // stats_type=2 (Packets)
 
+            // [recv, sent, flood_tx, direct_tx, flood_rx, direct_rx]
             let mut raw = Vec::new();
             for value in [1000u32, 500, 100, 400, 200, 800] {
                 raw.extend_from_slice(&value.to_le_bytes());
@@ -2058,8 +2105,13 @@ mod tests {
         });
 
         let stats = handler.get_packet_stats().await.unwrap();
-        assert_eq!(stats.recv, 1000);
-        assert_eq!(stats.recv_errors, None);
+        assert_eq!(stats.recv, 1000, "recv");
+        assert_eq!(stats.sent, 500, "sent");
+        assert_eq!(stats.flood_tx, 100, "flood_tx");
+        assert_eq!(stats.direct_tx, 400, "direct_tx");
+        assert_eq!(stats.flood_rx, 200, "flood_rx");
+        assert_eq!(stats.direct_rx, 800, "direct_rx");
+        assert_eq!(stats.recv_errors, None, "recv_errors");
     }
 
     #[tokio::test]

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -65,6 +65,7 @@ const CMD_FACTORY_RESET: u8 = 51;
 const CMD_PATH_DISCOVERY: u8 = 52;
 const CMD_SET_FLOOD_SCOPE: u8 = 54;
 const CMD_SEND_CONTROL_DATA: u8 = 55;
+const CMD_GET_STATS: u8 = 56;
 const CMD_SET_AUTOADD_CONFIG: u8 = 58;
 const CMD_GET_AUTOADD_CONFIG: u8 = 59;
 
@@ -677,6 +678,45 @@ impl CommandHandler {
         data.extend_from_slice(control_data);
         self.send(&data, Some(EventType::Ok)).await?;
         Ok(())
+    }
+
+    /// Get raw device stats for one category.
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type]
+    pub async fn get_stats(&self, category: StatsCategory) -> Result<StatsData> {
+        let data = [CMD_GET_STATS, category as u8];
+        let event_type = match category {
+            StatsCategory::Core => EventType::StatsCore,
+            StatsCategory::Radio => EventType::StatsRadio,
+            StatsCategory::Packets => EventType::StatsPackets,
+        };
+        let event = self.send(&data, Some(event_type)).await?;
+
+        match event.payload {
+            EventPayload::Stats(data) => Ok(data),
+            _ => Err(Error::protocol("Unexpected response to stats query")),
+        }
+    }
+
+    /// Get core device stats (battery, uptime, error count, queue length).
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=0]
+    pub async fn get_core_stats(&self) -> Result<CoreStatsData> {
+        self.get_stats(StatsCategory::Core).await?.as_core()
+    }
+
+    /// Get radio stats (noise floor, last RSSI/SNR, cumulative airtime).
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=1]
+    pub async fn get_radio_stats(&self) -> Result<RadioStatsData> {
+        self.get_stats(StatsCategory::Radio).await?.as_radio()
+    }
+
+    /// Get packet counters.
+    ///
+    /// Format: [CMD_GET_STATS=56][stats_type=2]
+    pub async fn get_packet_stats(&self) -> Result<PacketStatsData> {
+        self.get_stats(StatsCategory::Packets).await?.as_packets()
     }
 
     /// Export private key
@@ -1885,6 +1925,141 @@ mod tests {
 
         let result = handler.send_control_data(&[0x01, 0x02, 0x03]).await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_core_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 0]); // stats_type=0 (Core)
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsCore,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Core,
+                        raw: vec![0xAA],
+                    }),
+                ))
+                .await;
+        });
+
+        let result = handler.get_stats(StatsCategory::Core).await;
+        assert_eq!(result.unwrap().raw, vec![0xAA]);
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_unexpected_response_errors() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            rx.recv().await.unwrap();
+            // Right EventType, wrong payload shape.
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(EventType::StatsCore, EventPayload::None))
+                .await;
+        });
+
+        let result = handler.get_stats(StatsCategory::Core).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_core_stats_wire_format_and_decoding() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 0]);
+
+            let mut raw = Vec::new();
+            raw.extend_from_slice(&4012u16.to_le_bytes());
+            raw.extend_from_slice(&123456u32.to_le_bytes());
+            raw.extend_from_slice(&0u16.to_le_bytes());
+            raw.push(0);
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsCore,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Core,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_core_stats().await.unwrap();
+        assert_eq!(stats.battery_mv, 4012);
+        assert_eq!(stats.uptime_secs, 123456);
+    }
+
+    #[tokio::test]
+    async fn test_get_radio_stats_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 1]); // stats_type=1 (Radio)
+
+            let mut raw = Vec::new();
+            raw.extend_from_slice(&(-100i16).to_le_bytes());
+            raw.push((-70i8) as u8);
+            raw.push(20i8 as u8); // 20 / 4.0 = 5.0 dB
+            raw.extend_from_slice(&10u32.to_le_bytes());
+            raw.extend_from_slice(&20u32.to_le_bytes());
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsRadio,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Radio,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_radio_stats().await.unwrap();
+        assert_eq!(stats.noise_floor, -100);
+        assert_eq!(stats.last_rssi, -70);
+        assert_eq!(stats.last_snr, 5.0);
+    }
+
+    #[tokio::test]
+    async fn test_get_packet_stats_wire_format() {
+        let (handler, mut rx, dispatcher) = create_test_handler();
+
+        let dispatcher_clone = dispatcher.clone();
+        tokio::spawn(async move {
+            let sent = rx.recv().await.unwrap();
+            assert_eq!(sent, vec![CMD_GET_STATS, 2]); // stats_type=2 (Packets)
+
+            let mut raw = Vec::new();
+            for value in [1000u32, 500, 100, 400, 200, 800] {
+                raw.extend_from_slice(&value.to_le_bytes());
+            }
+
+            dispatcher_clone
+                .emit(MeshCoreEvent::new(
+                    EventType::StatsPackets,
+                    EventPayload::Stats(StatsData {
+                        category: StatsCategory::Packets,
+                        raw,
+                    }),
+                ))
+                .await;
+        });
+
+        let stats = handler.get_packet_stats().await.unwrap();
+        assert_eq!(stats.recv, 1000);
+        assert_eq!(stats.recv_errors, None);
     }
 
     #[tokio::test]

--- a/src/commands/base.rs
+++ b/src/commands/base.rs
@@ -682,8 +682,10 @@ impl CommandHandler {
 
     /// Get raw device stats for one category. `get_core_stats()`/
     /// `get_radio_stats()`/`get_packet_stats()` are typed convenience
-    /// wrappers over this; call this directly for a category that doesn't
-    /// have one yet.
+    /// wrappers over this; call this directly if you want the raw
+    /// [`StatsData::raw`] bytes (e.g. to log/forward them without decoding),
+    /// or for a future [`StatsCategory`] that doesn't have a typed wrapper
+    /// yet.
     ///
     /// Introduced in companion firmware `FIRMWARE_VER_CODE` 8+ (per the
     /// firmware's own inline comment on `CMD_GET_STATS`, from

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 use crate::packets::{PayloadType, RouteType};
-use crate::CHANNEL_SECRET_LEN;
+use crate::{Error, CHANNEL_SECRET_LEN};
 
 /// Event types emitted by MeshCore
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -571,12 +571,100 @@ pub struct StatsData {
     pub raw: Vec<u8>,
 }
 
+impl StatsData {
+    /// Decodes [`Self::raw`] as [`CoreStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Core`] or the payload is
+    /// malformed.
+    pub fn as_core(&self) -> crate::Result<CoreStatsData> {
+        if self.category != StatsCategory::Core {
+            return Err(Error::protocol("Not a core stats payload"));
+        }
+        crate::parsing::parse_core_stats(&self.raw)
+    }
+
+    /// Decodes [`Self::raw`] as [`RadioStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Radio`] or the payload is
+    /// malformed.
+    pub fn as_radio(&self) -> crate::Result<RadioStatsData> {
+        if self.category != StatsCategory::Radio {
+            return Err(Error::protocol("Not a radio stats payload"));
+        }
+        crate::parsing::parse_radio_stats(&self.raw)
+    }
+
+    /// Decodes [`Self::raw`] as [`PacketStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Packets`] or the payload is
+    /// malformed.
+    pub fn as_packets(&self) -> crate::Result<PacketStatsData> {
+        if self.category != StatsCategory::Packets {
+            return Err(Error::protocol("Not a packets stats payload"));
+        }
+        crate::parsing::parse_packet_stats(&self.raw)
+    }
+}
+
 /// Stats category
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatsCategory {
     Core,
     Radio,
     Packets,
+}
+
+/// Core device stats (`StatsCategory::Core`) — battery, uptime, error count
+/// and outbound queue length. Field names match `meshcore_py`'s
+/// `reader.py` dict keys exactly, for MQTT/JSON compatibility with
+/// downstream tools that already consume that shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoreStatsData {
+    /// Battery voltage, millivolts.
+    pub battery_mv: u16,
+    /// Device uptime, seconds.
+    pub uptime_secs: u32,
+    /// Error count/flags -- bit meanings are undocumented in the firmware
+    /// source, exposed here as an opaque value.
+    pub errors: u16,
+    /// Outbound message queue length.
+    pub queue_len: u8,
+}
+
+/// Radio stats (`StatsCategory::Radio`) — noise floor, last packet's
+/// signal quality, and cumulative airtime. Field names match
+/// `meshcore_py`'s `reader.py` dict keys exactly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RadioStatsData {
+    /// Radio noise floor, dBm.
+    pub noise_floor: i16,
+    /// RSSI of the last received packet, dBm.
+    pub last_rssi: i8,
+    /// SNR of the last received packet, dB -- already unscaled from the
+    /// firmware's ×4 wire encoding.
+    pub last_snr: f32,
+    /// Cumulative transmit airtime, seconds.
+    pub tx_air_secs: u32,
+    /// Cumulative receive airtime, seconds.
+    pub rx_air_secs: u32,
+}
+
+/// Packet counters (`StatsCategory::Packets`) — field names match
+/// `meshcore_py`'s `reader.py` dict keys exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PacketStatsData {
+    /// Total packets received.
+    pub recv: u32,
+    /// Total packets sent.
+    pub sent: u32,
+    /// Packets sent via flood routing.
+    pub flood_tx: u32,
+    /// Packets sent via direct routing.
+    pub direct_tx: u32,
+    /// Packets received via flood routing.
+    pub flood_rx: u32,
+    /// Packets received via direct routing.
+    pub direct_rx: u32,
+    /// Receive/CRC errors -- `None` on older firmware whose stats frame
+    /// doesn't report this field (26 bytes instead of 30).
+    pub recv_errors: Option<u32>,
 }
 
 /// RF log data from the device: pushed automatically for *every* packet the
@@ -1258,6 +1346,33 @@ mod tests {
     fn test_stats_category_eq() {
         assert_eq!(StatsCategory::Core, StatsCategory::Core);
         assert_ne!(StatsCategory::Core, StatsCategory::Radio);
+    }
+
+    #[test]
+    fn test_stats_data_as_core_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Radio,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_core().is_err());
+    }
+
+    #[test]
+    fn test_stats_data_as_radio_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Packets,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_radio().is_err());
+    }
+
+    #[test]
+    fn test_stats_data_as_packets_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Core,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_packets().is_err());
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 use crate::packets::{PayloadType, RouteType};
-use crate::CHANNEL_SECRET_LEN;
+use crate::{Error, CHANNEL_SECRET_LEN};
 
 /// Event types emitted by MeshCore
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -571,12 +571,100 @@ pub struct StatsData {
     pub raw: Vec<u8>,
 }
 
+impl StatsData {
+    /// Decodes [`Self::raw`] as [`CoreStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Core`] or the payload is
+    /// malformed.
+    pub fn as_core(&self) -> crate::Result<CoreStatsData> {
+        if self.category != StatsCategory::Core {
+            return Err(Error::protocol("Not a core stats payload"));
+        }
+        crate::parsing::parse_core_stats(&self.raw)
+    }
+
+    /// Decodes [`Self::raw`] as [`RadioStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Radio`] or the payload is
+    /// malformed.
+    pub fn as_radio(&self) -> crate::Result<RadioStatsData> {
+        if self.category != StatsCategory::Radio {
+            return Err(Error::protocol("Not a radio stats payload"));
+        }
+        crate::parsing::parse_radio_stats(&self.raw)
+    }
+
+    /// Decodes [`Self::raw`] as [`PacketStatsData`]. Errors if
+    /// [`Self::category`] isn't [`StatsCategory::Packets`] or the payload is
+    /// malformed.
+    pub fn as_packets(&self) -> crate::Result<PacketStatsData> {
+        if self.category != StatsCategory::Packets {
+            return Err(Error::protocol("Not a packets stats payload"));
+        }
+        crate::parsing::parse_packet_stats(&self.raw)
+    }
+}
+
 /// Stats category
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StatsCategory {
     Core,
     Radio,
     Packets,
+}
+
+/// Core device stats (`StatsCategory::Core`) — battery, uptime, error count
+/// and outbound queue length. Field names match `meshcore_py`'s
+/// `reader.py` dict keys exactly, for MQTT/JSON compatibility with
+/// downstream tools that already consume that shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoreStatsData {
+    /// Battery voltage, millivolts.
+    pub battery_mv: u16,
+    /// Device uptime, seconds.
+    pub uptime_secs: u32,
+    /// Error count/flags -- bit meanings are undocumented in the firmware
+    /// source, exposed here as an opaque value.
+    pub errors: u16,
+    /// Outbound message queue length.
+    pub queue_len: u8,
+}
+
+/// Radio stats (`StatsCategory::Radio`) — noise floor, last packet's
+/// signal quality, and cumulative airtime. Field names match
+/// `meshcore_py`'s `reader.py` dict keys exactly.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RadioStatsData {
+    /// Radio noise floor, dBm.
+    pub noise_floor: i16,
+    /// RSSI of the last received packet, dBm.
+    pub last_rssi: i8,
+    /// SNR of the last received packet, dB -- already unscaled from the
+    /// firmware's ×4 wire encoding.
+    pub last_snr: f32,
+    /// Cumulative transmit airtime, seconds.
+    pub tx_air_secs: u32,
+    /// Cumulative receive airtime, seconds.
+    pub rx_air_secs: u32,
+}
+
+/// Packet counters (`StatsCategory::Packets`) — field names match
+/// `meshcore_py`'s `reader.py` dict keys exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PacketStatsData {
+    /// Total packets received.
+    pub recv: u32,
+    /// Total packets sent.
+    pub sent: u32,
+    /// Packets sent via flood routing.
+    pub flood_tx: u32,
+    /// Packets sent via direct routing.
+    pub direct_tx: u32,
+    /// Packets received via flood routing.
+    pub flood_rx: u32,
+    /// Packets received via direct routing.
+    pub direct_rx: u32,
+    /// Receive/CRC errors -- `None` on older firmware whose stats frame
+    /// doesn't report this field (26 bytes instead of 30).
+    pub recv_errors: Option<u32>,
 }
 
 /// RF log data from the device: pushed automatically for *every* packet the
@@ -1299,6 +1387,33 @@ mod tests {
     fn test_stats_category_eq() {
         assert_eq!(StatsCategory::Core, StatsCategory::Core);
         assert_ne!(StatsCategory::Core, StatsCategory::Radio);
+    }
+
+    #[test]
+    fn test_stats_data_as_core_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Radio,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_core().is_err());
+    }
+
+    #[test]
+    fn test_stats_data_as_radio_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Packets,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_radio().is_err());
+    }
+
+    #[test]
+    fn test_stats_data_as_packets_errors_on_wrong_category() {
+        let stats = StatsData {
+            category: StatsCategory::Core,
+            raw: Vec::new(),
+        };
+        assert!(stats.as_packets().is_err());
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -576,30 +576,54 @@ impl StatsData {
     /// [`Self::category`] isn't [`StatsCategory::Core`] or the payload is
     /// malformed.
     pub fn as_core(&self) -> crate::Result<CoreStatsData> {
-        if self.category != StatsCategory::Core {
-            return Err(Error::protocol("Not a core stats payload"));
-        }
-        crate::parsing::parse_core_stats(&self.raw)
+        self.try_into()
     }
 
     /// Decodes [`Self::raw`] as [`RadioStatsData`]. Errors if
     /// [`Self::category`] isn't [`StatsCategory::Radio`] or the payload is
     /// malformed.
     pub fn as_radio(&self) -> crate::Result<RadioStatsData> {
-        if self.category != StatsCategory::Radio {
-            return Err(Error::protocol("Not a radio stats payload"));
-        }
-        crate::parsing::parse_radio_stats(&self.raw)
+        self.try_into()
     }
 
     /// Decodes [`Self::raw`] as [`PacketStatsData`]. Errors if
     /// [`Self::category`] isn't [`StatsCategory::Packets`] or the payload is
     /// malformed.
     pub fn as_packets(&self) -> crate::Result<PacketStatsData> {
-        if self.category != StatsCategory::Packets {
+        self.try_into()
+    }
+}
+
+impl TryFrom<&StatsData> for CoreStatsData {
+    type Error = Error;
+
+    fn try_from(stats: &StatsData) -> crate::Result<Self> {
+        if stats.category != StatsCategory::Core {
+            return Err(Error::protocol("Not a core stats payload"));
+        }
+        crate::parsing::parse_core_stats(&stats.raw)
+    }
+}
+
+impl TryFrom<&StatsData> for RadioStatsData {
+    type Error = Error;
+
+    fn try_from(stats: &StatsData) -> crate::Result<Self> {
+        if stats.category != StatsCategory::Radio {
+            return Err(Error::protocol("Not a radio stats payload"));
+        }
+        crate::parsing::parse_radio_stats(&stats.raw)
+    }
+}
+
+impl TryFrom<&StatsData> for PacketStatsData {
+    type Error = Error;
+
+    fn try_from(stats: &StatsData) -> crate::Result<Self> {
+        if stats.category != StatsCategory::Packets {
             return Err(Error::protocol("Not a packets stats payload"));
         }
-        crate::parsing::parse_packet_stats(&self.raw)
+        crate::parsing::parse_packet_stats(&stats.raw)
     }
 }
 

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -5,9 +5,10 @@ use std::collections::HashMap;
 use crate::error::Error;
 use crate::events::{
     AclEntry, AdvertResponseData, AdvertisementData, BatteryInfo, ChannelInfoData, ChannelMessage,
-    Contact, ContactMessage, DeviceInfoData, DiscoverEntry, MeshPacketHeader, MmaEntry,
-    MsgSentInfo, Neighbour, NeighboursData, PathDiscoveryResponseData, PathUpdateData,
-    RawAdvertisement, SelfInfo, StatsCategory, StatsData, StatusData, TraceHop, TraceInfo,
+    Contact, ContactMessage, CoreStatsData, DeviceInfoData, DiscoverEntry, MeshPacketHeader,
+    MmaEntry, MsgSentInfo, Neighbour, NeighboursData, PacketStatsData, PathDiscoveryResponseData,
+    PathUpdateData, RadioStatsData, RawAdvertisement, SelfInfo, StatsCategory, StatsData,
+    StatusData, TraceHop, TraceInfo,
 };
 use crate::packets::{PayloadType, RouteType};
 use crate::{Result, CHANNEL_NAME_LEN, CHANNEL_SECRET_LEN};
@@ -1003,6 +1004,84 @@ pub fn parse_stats(payload: &[u8]) -> Result<StatsData> {
     Ok(StatsData {
         category,
         raw: payload[1..].to_vec(),
+    })
+}
+
+/// Length of a [`StatsCategory::Core`] payload (`raw`, i.e. after the
+/// stats-type byte): `battery_mv:u16, uptime_secs:u32, errors:u16,
+/// queue_len:u8`.
+const CORE_STATS_LEN: usize = 9;
+
+/// Parses a [`StatsCategory::Core`] payload's `raw` bytes into
+/// [`CoreStatsData`].
+pub fn parse_core_stats(data: &[u8]) -> Result<CoreStatsData> {
+    if data.len() < CORE_STATS_LEN {
+        return Err(Error::protocol("Core stats payload too short"));
+    }
+    Ok(CoreStatsData {
+        battery_mv: read_u16_le(data, 0)?,
+        uptime_secs: read_u32_le(data, 2)?,
+        errors: read_u16_le(data, 6)?,
+        queue_len: *data
+            .get(8)
+            .ok_or_else(|| Error::protocol("Core stats payload too short"))?,
+    })
+}
+
+/// Length of a [`StatsCategory::Radio`] payload (`raw`): `noise_floor:i16,
+/// last_rssi:i8, last_snr_scaled:i8, tx_air_secs:u32, rx_air_secs:u32`.
+const RADIO_STATS_LEN: usize = 12;
+
+/// Parses a [`StatsCategory::Radio`] payload's `raw` bytes into
+/// [`RadioStatsData`]. `last_snr` is unscaled from the firmware's ×4
+/// wire encoding (`last_snr_scaled as f32 / 4.0`).
+pub fn parse_radio_stats(data: &[u8]) -> Result<RadioStatsData> {
+    if data.len() < RADIO_STATS_LEN {
+        return Err(Error::protocol("Radio stats payload too short"));
+    }
+    let last_rssi = *data
+        .get(2)
+        .ok_or_else(|| Error::protocol("Radio stats payload too short"))? as i8;
+    let last_snr_scaled = *data
+        .get(3)
+        .ok_or_else(|| Error::protocol("Radio stats payload too short"))?
+        as i8;
+    Ok(RadioStatsData {
+        noise_floor: read_i16_le(data, 0)?,
+        last_rssi,
+        last_snr: last_snr_scaled as f32 / 4.0,
+        tx_air_secs: read_u32_le(data, 4)?,
+        rx_air_secs: read_u32_le(data, 8)?,
+    })
+}
+
+/// Length of a [`StatsCategory::Packets`] payload (`raw`) without the
+/// optional trailing `recv_errors:u32` (older firmware).
+const PACKET_STATS_LEN: usize = 24;
+/// Length of a [`StatsCategory::Packets`] payload (`raw`) including
+/// `recv_errors:u32` (newer firmware).
+const PACKET_STATS_LEN_WITH_ERRORS: usize = 28;
+
+/// Parses a [`StatsCategory::Packets`] payload's `raw` bytes into
+/// [`PacketStatsData`]. Accepts either the legacy 24-byte frame
+/// (`recv_errors` becomes `None`) or the newer 28-byte one.
+pub fn parse_packet_stats(data: &[u8]) -> Result<PacketStatsData> {
+    if data.len() < PACKET_STATS_LEN {
+        return Err(Error::protocol("Packet stats payload too short"));
+    }
+    let recv_errors = if data.len() >= PACKET_STATS_LEN_WITH_ERRORS {
+        Some(read_u32_le(data, 24)?)
+    } else {
+        None
+    };
+    Ok(PacketStatsData {
+        recv: read_u32_le(data, 0)?,
+        sent: read_u32_le(data, 4)?,
+        flood_tx: read_u32_le(data, 8)?,
+        direct_tx: read_u32_le(data, 12)?,
+        flood_rx: read_u32_le(data, 16)?,
+        direct_rx: read_u32_le(data, 20)?,
+        recv_errors,
     })
 }
 
@@ -2416,6 +2495,99 @@ mod tests {
         let data = [99, 0xFF];
         let stats = parse_stats(&data).unwrap();
         assert_eq!(stats.category, StatsCategory::Core);
+    }
+
+    // ========== parse_core_stats tests ==========
+
+    #[test]
+    fn test_parse_core_stats_too_short() {
+        assert!(parse_core_stats(&[]).is_err());
+        assert!(parse_core_stats(&[0; 8]).is_err()); // need 9
+    }
+
+    #[test]
+    fn test_parse_core_stats_valid() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&4012u16.to_le_bytes()); // battery_mv
+        data.extend_from_slice(&123456u32.to_le_bytes()); // uptime_secs
+        data.extend_from_slice(&7u16.to_le_bytes()); // errors
+        data.push(3); // queue_len
+
+        let stats = parse_core_stats(&data).unwrap();
+        assert_eq!(stats.battery_mv, 4012);
+        assert_eq!(stats.uptime_secs, 123456);
+        assert_eq!(stats.errors, 7);
+        assert_eq!(stats.queue_len, 3);
+    }
+
+    // ========== parse_radio_stats tests ==========
+
+    #[test]
+    fn test_parse_radio_stats_too_short() {
+        assert!(parse_radio_stats(&[]).is_err());
+        assert!(parse_radio_stats(&[0; 11]).is_err()); // need 12
+    }
+
+    #[test]
+    fn test_parse_radio_stats_valid() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-120i16).to_le_bytes()); // noise_floor
+        data.push((-80i8) as u8); // last_rssi
+        data.push((33i8) as u8); // last_snr_scaled (33 / 4.0 = 8.25 dB)
+        data.extend_from_slice(&120u32.to_le_bytes()); // tx_air_secs
+        data.extend_from_slice(&340u32.to_le_bytes()); // rx_air_secs
+
+        let stats = parse_radio_stats(&data).unwrap();
+        assert_eq!(stats.noise_floor, -120);
+        assert_eq!(stats.last_rssi, -80);
+        assert_eq!(stats.last_snr, 8.25);
+        assert_eq!(stats.tx_air_secs, 120);
+        assert_eq!(stats.rx_air_secs, 340);
+    }
+
+    // ========== parse_packet_stats tests ==========
+
+    #[test]
+    fn test_parse_packet_stats_too_short() {
+        assert!(parse_packet_stats(&[]).is_err());
+        assert!(parse_packet_stats(&[0; 23]).is_err()); // need at least 24
+    }
+
+    #[test]
+    fn test_parse_packet_stats_legacy_26_byte_frame_has_no_recv_errors() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&1000u32.to_le_bytes()); // recv
+        data.extend_from_slice(&500u32.to_le_bytes()); // sent
+        data.extend_from_slice(&100u32.to_le_bytes()); // flood_tx
+        data.extend_from_slice(&400u32.to_le_bytes()); // direct_tx
+        data.extend_from_slice(&200u32.to_le_bytes()); // flood_rx
+        data.extend_from_slice(&800u32.to_le_bytes()); // direct_rx
+        assert_eq!(data.len(), 24);
+
+        let stats = parse_packet_stats(&data).unwrap();
+        assert_eq!(stats.recv, 1000);
+        assert_eq!(stats.sent, 500);
+        assert_eq!(stats.flood_tx, 100);
+        assert_eq!(stats.direct_tx, 400);
+        assert_eq!(stats.flood_rx, 200);
+        assert_eq!(stats.direct_rx, 800);
+        assert_eq!(stats.recv_errors, None);
+    }
+
+    #[test]
+    fn test_parse_packet_stats_30_byte_frame_has_recv_errors() {
+        let mut data = Vec::new();
+        data.extend_from_slice(&1000u32.to_le_bytes());
+        data.extend_from_slice(&500u32.to_le_bytes());
+        data.extend_from_slice(&100u32.to_le_bytes());
+        data.extend_from_slice(&400u32.to_le_bytes());
+        data.extend_from_slice(&200u32.to_le_bytes());
+        data.extend_from_slice(&800u32.to_le_bytes());
+        data.extend_from_slice(&5u32.to_le_bytes()); // recv_errors
+        assert_eq!(data.len(), 28);
+
+        let stats = parse_packet_stats(&data).unwrap();
+        assert_eq!(stats.recv_errors, Some(5));
     }
 
     // ========== parse_advertisement tests ==========

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -998,7 +998,7 @@ pub fn parse_stats(payload: &[u8]) -> Result<StatsData> {
         0 => StatsCategory::Core,
         1 => StatsCategory::Radio,
         2 => StatsCategory::Packets,
-        _ => StatsCategory::Core,
+        _ => return Err(Error::protocol("Unknown stats category")),
     };
 
     Ok(StatsData {
@@ -2491,10 +2491,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_stats_unknown_defaults_to_core() {
+    fn test_parse_stats_unknown_category_errors() {
         let data = [99, 0xFF];
-        let stats = parse_stats(&data).unwrap();
-        assert_eq!(stats.category, StatsCategory::Core);
+        assert!(parse_stats(&data).is_err());
     }
 
     // ========== parse_core_stats tests ==========

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1094,9 +1094,13 @@ const PACKET_STATS_LEN_WITH_ERRORS: usize = PACKET_RECV_ERRORS_OFFSET + PACKET_F
 
 /// Parses a [`StatsCategory::Packets`] payload's `raw` bytes into
 /// [`PacketStatsData`]. Accepts either the legacy 24-byte frame
-/// (`recv_errors` becomes `None`) or the newer 28-byte one.
+/// (`recv_errors` becomes `None`) or the newer 28-byte one. Rejects lengths
+/// in between as a truncated `recv_errors` field rather than silently
+/// treating them as a legacy frame.
 pub fn parse_packet_stats(data: &[u8]) -> Result<PacketStatsData> {
-    if data.len() < PACKET_STATS_LEN {
+    if data.len() < PACKET_STATS_LEN
+        || (data.len() > PACKET_STATS_LEN && data.len() < PACKET_STATS_LEN_WITH_ERRORS)
+    {
         return Err(Error::protocol("Packet stats payload too short"));
     }
     let recv_errors = if data.len() >= PACKET_STATS_LEN_WITH_ERRORS {
@@ -2608,6 +2612,18 @@ mod tests {
             parse_packet_stats(&[0; 23]), // need at least 24
             Err(Error::Protocol(_))
         ));
+    }
+
+    #[test]
+    fn test_parse_packet_stats_rejects_truncated_recv_errors() {
+        // 25, 26, 27 bytes: past the 24-byte legacy frame but short of the
+        // 28-byte recv_errors:u32 field -- a truncated field, not a legacy frame.
+        for len in [25, 26, 27] {
+            assert!(
+                matches!(parse_packet_stats(&vec![0; len]), Err(Error::Protocol(_))),
+                "expected Err(Error::Protocol) for len={len}"
+            );
+        }
     }
 
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1007,10 +1007,19 @@ pub fn parse_stats(payload: &[u8]) -> Result<StatsData> {
     })
 }
 
+const CORE_BATTERY_MV_LEN: usize = 2;
+const CORE_UPTIME_SECS_LEN: usize = 4;
+const CORE_ERRORS_LEN: usize = 2;
+const CORE_QUEUE_LEN_LEN: usize = 1;
+
+const CORE_BATTERY_MV_OFFSET: usize = 0;
+const CORE_UPTIME_SECS_OFFSET: usize = CORE_BATTERY_MV_OFFSET + CORE_BATTERY_MV_LEN;
+const CORE_ERRORS_OFFSET: usize = CORE_UPTIME_SECS_OFFSET + CORE_UPTIME_SECS_LEN;
+const CORE_QUEUE_LEN_OFFSET: usize = CORE_ERRORS_OFFSET + CORE_ERRORS_LEN;
 /// Length of a [`StatsCategory::Core`] payload (`raw`, i.e. after the
 /// stats-type byte): `battery_mv:u16, uptime_secs:u32, errors:u16,
 /// queue_len:u8`.
-const CORE_STATS_LEN: usize = 9;
+const CORE_STATS_LEN: usize = CORE_QUEUE_LEN_OFFSET + CORE_QUEUE_LEN_LEN;
 
 /// Parses a [`StatsCategory::Core`] payload's `raw` bytes into
 /// [`CoreStatsData`].
@@ -1019,18 +1028,29 @@ pub fn parse_core_stats(data: &[u8]) -> Result<CoreStatsData> {
         return Err(Error::protocol("Core stats payload too short"));
     }
     Ok(CoreStatsData {
-        battery_mv: read_u16_le(data, 0)?,
-        uptime_secs: read_u32_le(data, 2)?,
-        errors: read_u16_le(data, 6)?,
+        battery_mv: read_u16_le(data, CORE_BATTERY_MV_OFFSET)?,
+        uptime_secs: read_u32_le(data, CORE_UPTIME_SECS_OFFSET)?,
+        errors: read_u16_le(data, CORE_ERRORS_OFFSET)?,
         queue_len: *data
-            .get(8)
+            .get(CORE_QUEUE_LEN_OFFSET)
             .ok_or_else(|| Error::protocol("Core stats payload too short"))?,
     })
 }
 
+const RADIO_NOISE_FLOOR_LEN: usize = 2;
+const RADIO_LAST_RSSI_LEN: usize = 1;
+const RADIO_LAST_SNR_LEN: usize = 1;
+const RADIO_TX_AIR_SECS_LEN: usize = 4;
+const RADIO_RX_AIR_SECS_LEN: usize = 4;
+
+const RADIO_NOISE_FLOOR_OFFSET: usize = 0;
+const RADIO_LAST_RSSI_OFFSET: usize = RADIO_NOISE_FLOOR_OFFSET + RADIO_NOISE_FLOOR_LEN;
+const RADIO_LAST_SNR_OFFSET: usize = RADIO_LAST_RSSI_OFFSET + RADIO_LAST_RSSI_LEN;
+const RADIO_TX_AIR_SECS_OFFSET: usize = RADIO_LAST_SNR_OFFSET + RADIO_LAST_SNR_LEN;
+const RADIO_RX_AIR_SECS_OFFSET: usize = RADIO_TX_AIR_SECS_OFFSET + RADIO_TX_AIR_SECS_LEN;
 /// Length of a [`StatsCategory::Radio`] payload (`raw`): `noise_floor:i16,
 /// last_rssi:i8, last_snr_scaled:i8, tx_air_secs:u32, rx_air_secs:u32`.
-const RADIO_STATS_LEN: usize = 12;
+const RADIO_STATS_LEN: usize = RADIO_RX_AIR_SECS_OFFSET + RADIO_RX_AIR_SECS_LEN;
 
 /// Parses a [`StatsCategory::Radio`] payload's `raw` bytes into
 /// [`RadioStatsData`]. `last_snr` is unscaled from the firmware's ×4
@@ -1040,27 +1060,37 @@ pub fn parse_radio_stats(data: &[u8]) -> Result<RadioStatsData> {
         return Err(Error::protocol("Radio stats payload too short"));
     }
     let last_rssi = *data
-        .get(2)
+        .get(RADIO_LAST_RSSI_OFFSET)
         .ok_or_else(|| Error::protocol("Radio stats payload too short"))? as i8;
     let last_snr_scaled = *data
-        .get(3)
+        .get(RADIO_LAST_SNR_OFFSET)
         .ok_or_else(|| Error::protocol("Radio stats payload too short"))?
         as i8;
     Ok(RadioStatsData {
-        noise_floor: read_i16_le(data, 0)?,
+        noise_floor: read_i16_le(data, RADIO_NOISE_FLOOR_OFFSET)?,
         last_rssi,
         last_snr: last_snr_scaled as f32 / 4.0,
-        tx_air_secs: read_u32_le(data, 4)?,
-        rx_air_secs: read_u32_le(data, 8)?,
+        tx_air_secs: read_u32_le(data, RADIO_TX_AIR_SECS_OFFSET)?,
+        rx_air_secs: read_u32_le(data, RADIO_RX_AIR_SECS_OFFSET)?,
     })
 }
 
+/// Byte length of every [`StatsCategory::Packets`] field -- they're all `u32`.
+const PACKET_FIELD_LEN: usize = 4;
+
+const PACKET_RECV_OFFSET: usize = 0;
+const PACKET_SENT_OFFSET: usize = PACKET_RECV_OFFSET + PACKET_FIELD_LEN;
+const PACKET_FLOOD_TX_OFFSET: usize = PACKET_SENT_OFFSET + PACKET_FIELD_LEN;
+const PACKET_DIRECT_TX_OFFSET: usize = PACKET_FLOOD_TX_OFFSET + PACKET_FIELD_LEN;
+const PACKET_FLOOD_RX_OFFSET: usize = PACKET_DIRECT_TX_OFFSET + PACKET_FIELD_LEN;
+const PACKET_DIRECT_RX_OFFSET: usize = PACKET_FLOOD_RX_OFFSET + PACKET_FIELD_LEN;
 /// Length of a [`StatsCategory::Packets`] payload (`raw`) without the
 /// optional trailing `recv_errors:u32` (older firmware).
-const PACKET_STATS_LEN: usize = 24;
+const PACKET_STATS_LEN: usize = PACKET_DIRECT_RX_OFFSET + PACKET_FIELD_LEN;
+const PACKET_RECV_ERRORS_OFFSET: usize = PACKET_STATS_LEN;
 /// Length of a [`StatsCategory::Packets`] payload (`raw`) including
 /// `recv_errors:u32` (newer firmware).
-const PACKET_STATS_LEN_WITH_ERRORS: usize = 28;
+const PACKET_STATS_LEN_WITH_ERRORS: usize = PACKET_RECV_ERRORS_OFFSET + PACKET_FIELD_LEN;
 
 /// Parses a [`StatsCategory::Packets`] payload's `raw` bytes into
 /// [`PacketStatsData`]. Accepts either the legacy 24-byte frame
@@ -1070,17 +1100,17 @@ pub fn parse_packet_stats(data: &[u8]) -> Result<PacketStatsData> {
         return Err(Error::protocol("Packet stats payload too short"));
     }
     let recv_errors = if data.len() >= PACKET_STATS_LEN_WITH_ERRORS {
-        Some(read_u32_le(data, 24)?)
+        Some(read_u32_le(data, PACKET_RECV_ERRORS_OFFSET)?)
     } else {
         None
     };
     Ok(PacketStatsData {
-        recv: read_u32_le(data, 0)?,
-        sent: read_u32_le(data, 4)?,
-        flood_tx: read_u32_le(data, 8)?,
-        direct_tx: read_u32_le(data, 12)?,
-        flood_rx: read_u32_le(data, 16)?,
-        direct_rx: read_u32_le(data, 20)?,
+        recv: read_u32_le(data, PACKET_RECV_OFFSET)?,
+        sent: read_u32_le(data, PACKET_SENT_OFFSET)?,
+        flood_tx: read_u32_le(data, PACKET_FLOOD_TX_OFFSET)?,
+        direct_tx: read_u32_le(data, PACKET_DIRECT_TX_OFFSET)?,
+        flood_rx: read_u32_le(data, PACKET_FLOOD_RX_OFFSET)?,
+        direct_rx: read_u32_le(data, PACKET_DIRECT_RX_OFFSET)?,
         recv_errors,
     })
 }
@@ -2493,15 +2523,27 @@ mod tests {
     #[test]
     fn test_parse_stats_unknown_category_errors() {
         let data = [99, 0xFF];
-        assert!(parse_stats(&data).is_err());
+        assert!(matches!(parse_stats(&data), Err(Error::Protocol(_))));
     }
 
     // ========== parse_core_stats tests ==========
 
     #[test]
     fn test_parse_core_stats_too_short() {
-        assert!(parse_core_stats(&[]).is_err());
-        assert!(parse_core_stats(&[0; 8]).is_err()); // need 9
+        assert!(matches!(parse_core_stats(&[]), Err(Error::Protocol(_))));
+        assert!(matches!(
+            parse_core_stats(&[0; 8]), // need 9
+            Err(Error::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn test_core_stats_offset_constants() {
+        assert_eq!(CORE_BATTERY_MV_OFFSET, 0);
+        assert_eq!(CORE_UPTIME_SECS_OFFSET, 2);
+        assert_eq!(CORE_ERRORS_OFFSET, 6);
+        assert_eq!(CORE_QUEUE_LEN_OFFSET, 8);
+        assert_eq!(CORE_STATS_LEN, 9);
     }
 
     #[test]
@@ -2523,8 +2565,21 @@ mod tests {
 
     #[test]
     fn test_parse_radio_stats_too_short() {
-        assert!(parse_radio_stats(&[]).is_err());
-        assert!(parse_radio_stats(&[0; 11]).is_err()); // need 12
+        assert!(matches!(parse_radio_stats(&[]), Err(Error::Protocol(_))));
+        assert!(matches!(
+            parse_radio_stats(&[0; 11]), // need 12
+            Err(Error::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn test_radio_stats_offset_constants() {
+        assert_eq!(RADIO_NOISE_FLOOR_OFFSET, 0);
+        assert_eq!(RADIO_LAST_RSSI_OFFSET, 2);
+        assert_eq!(RADIO_LAST_SNR_OFFSET, 3);
+        assert_eq!(RADIO_TX_AIR_SECS_OFFSET, 4);
+        assert_eq!(RADIO_RX_AIR_SECS_OFFSET, 8);
+        assert_eq!(RADIO_STATS_LEN, 12);
     }
 
     #[test]
@@ -2548,8 +2603,24 @@ mod tests {
 
     #[test]
     fn test_parse_packet_stats_too_short() {
-        assert!(parse_packet_stats(&[]).is_err());
-        assert!(parse_packet_stats(&[0; 23]).is_err()); // need at least 24
+        assert!(matches!(parse_packet_stats(&[]), Err(Error::Protocol(_))));
+        assert!(matches!(
+            parse_packet_stats(&[0; 23]), // need at least 24
+            Err(Error::Protocol(_))
+        ));
+    }
+
+    #[test]
+    fn test_packet_stats_offset_constants() {
+        assert_eq!(PACKET_RECV_OFFSET, 0);
+        assert_eq!(PACKET_SENT_OFFSET, 4);
+        assert_eq!(PACKET_FLOOD_TX_OFFSET, 8);
+        assert_eq!(PACKET_DIRECT_TX_OFFSET, 12);
+        assert_eq!(PACKET_FLOOD_RX_OFFSET, 16);
+        assert_eq!(PACKET_DIRECT_RX_OFFSET, 20);
+        assert_eq!(PACKET_STATS_LEN, 24);
+        assert_eq!(PACKET_RECV_ERRORS_OFFSET, 24);
+        assert_eq!(PACKET_STATS_LEN_WITH_ERRORS, 28);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `CMD_GET_STATS=56` support, verified against the firmware (`examples/companion_radio/MyMesh.cpp`): request is `[CMD_GET_STATS][stats_type]`, response is `[RESP_CODE_STATS][stats_type]` followed by category-specific little-endian fields.
- `StatsData.raw` (previously left as opaque bytes) is now decoded into typed `CoreStatsData`/`RadioStatsData`/`PacketStatsData`, with field names matching `meshcore_py`'s `reader.py` dict keys exactly (`battery_mv`, `uptime_secs`, `errors`, `queue_len`; `noise_floor`, `last_rssi`, `last_snr` unscaled; `recv`, `sent`, `flood_tx`, `direct_tx`, `flood_rx`, `direct_rx`, `recv_errors`) — keeps downstream JSON/MQTT consumers of this port compatible.
- Packet stats accepts both the legacy 26-byte frame and the newer 30-byte one with `recv_errors`.
- New `get_core_stats()`/`get_radio_stats()`/`get_packet_stats()` convenience methods (mirroring `get_channel`'s typed-return style) plus the lower-level `get_stats(category)`.
- New `examples/node_stats.rs`, README updated.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --tests --no-deps --all-features --all-targets`
- [x] `cargo test --all-features` — 419 tests + 2 doc-tests, all passing
- [x] `cargo build --release` and `cargo publish --dry-run --allow-dirty --no-verify`
- [x] `jonesy` — 0 panic points
- [x] `cargo llvm-cov` — new code fully covered
- [x] `examples/node_stats.rs` run live against a real node (BLE, `MeshCore-F4FEZ_Tracker_2`):

```
Connecting via BLE to MeshCore-F4FEZ_Tracker_2...
Connected to device: F4FEZ_Tracker_2

Fetching core stats...
  battery_mv:   4561
  uptime_secs:  486247
  errors:       0
  queue_len:    0

Fetching radio stats...
  noise_floor:  -116 dBm
  last_rssi:    -113 dBm
  last_snr:     2 dB
  tx_air_secs:  0
  rx_air_secs:  6417

Fetching packet stats...
  recv:         8104
  sent:         0
  flood_tx:     0
  direct_tx:    0
  flood_rx:     7615
  direct_rx:    489
  recv_errors:  350
```

`recv_errors: Some(350)` confirms this device sends the newer 30-byte packets-stats frame rather than the legacy 26-byte one — both are exercised by the parsing unit tests.